### PR TITLE
Generalize Menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,14 @@ the static webpages:
 * `:slug: path/to/rendered/file`
 
   This is used as the link in the ``<a href=''>`` tag.
+
+#### Direct Templates
+
+Direct templates are their own animal. You cannot add metadata to a direct
+template, so if you want to include one in your menu you have to add the
+information directly to the site's `pelicanconf.py` like this:
+
+```
+DIRECT_TEMPLATE_INFO = [
+        {'parent': u'top', 'link': '/blog', 'name': 'Blog', 'weight': 5, 'children': []}]
+```

--- a/README.md
+++ b/README.md
@@ -37,35 +37,18 @@ child4                                              child4 -- gchild1
 The main menu is generated using Jinja2 templating. This requires metadata in
 the static webpages:
 
-* `:order:`
+* `:menu: <parent_name>, <page_name>, <menu_weight>; <parent2>, <name2>, <weight2>; ...`
 
-  Required integer on all pages (including blog posts), the top menu items
-  (`thingN` above) must be in incremental order unseparated by submenu items
+  This metadata is required for pages to be included in the menu. Each menu
+  location is delimited by a semicolon (';'). Menu items can have one or
+  multiple locations in the menu.
 
-* `:title:`
+  - `<parent_name` is the name of the menu item above the current item
+  - `<page_name>` is the name of the current item that will be displayed in the
+     menu
+  - `<menu_weight>` is the weight of the menu item. Items with higher weights
+    appear lower on the menu.
 
-  Sets the label for the menu item, not required if page title exists (when
-  using RestructuredText)
+* `:slug: path/to/rendered/file`
 
-* `:top_menu:`
-
-  If set to `parent`, this item exists in the top portion of the menu
-
-* `:menu_child:`
-
-  If this field matches another page's `menu_parent` field, that page will be
-  placed under this page in the child position. This field is required whenever
-  a menu item will have a child **or** a grandchild.
-
-* `:menu_parent:`
-
-  See `menu_child`
-
-* `:duplicate_name:`
-
-  Allows a page to be listed in the top menu as well as directly below it in the
-  corresponding submenu. The label will be set to the `duplicate_name` value
-
-* `:menu_gchild:`
-
-  Same relationship to `menu_parent` as `menu_child`, but for a grandchild
+  This is used as the link in the ``<a href=''>`` tag.

--- a/README.md
+++ b/README.md
@@ -7,3 +7,65 @@ This theme is currently being used by the
 [master branch](https://github.com/osuosl/dougfir-pelican-theme/tree/master) and
 by the [OSU CASS Pelican Site](https://github.com/osuosl/cass-pelican) on the
 [cass-pelican branch](https://github.com/osuosl/dougfir-pelican-theme/tree/cass-pelican)
+
+Usage
+-----
+
+This theme is intended to provide general formatting for pelican sites used by
+the OSU Open Source Lab. Several features are implemented in a very general way
+to allow for usage by different websites. These features require additional
+setup in the website themselves.
+
+### Menu
+
+This theme creates a main menu in the following format:
+
+```
+thing1              thing2              thing3      thing4
+   |                   |                   |           |
+child1              child1 -- gchild1   child1      child1
+   |                   |         |         |           |
+child2 -- gchild1   child2    gchild2   child2      child2
+   |         |                   |                     |
+child3    gchild2             gchild3               child3
+   |                                                   |
+child4                                              child4 -- gchild1
+                                                                 |
+                                                              gchild2
+```
+
+The main menu is generated using Jinja2 templating. This requires metadata in
+the static webpages:
+
+* `:order:`
+
+  Required integer on all pages (including blog posts), the top menu items
+  (`thingN` above) must be in incremental order unseparated by submenu items
+
+* `:title:`
+
+  Sets the label for the menu item, not required if page title exists (when
+  using RestructuredText)
+
+* `:top_menu:`
+
+  If set to `parent`, this item exists in the top portion of the menu
+
+* `:menu_child:`
+
+  If this field matches another page's `menu_parent` field, that page will be
+  placed under this page in the child position. This field is required whenever
+  a menu item will have a child **or** a grandchild.
+
+* `:menu_parent:`
+
+  See `menu_child`
+
+* `:duplicate_name:`
+
+  Allows a page to be listed in the top menu as well as directly below it in the
+  corresponding submenu. The label will be set to the `duplicate_name` value
+
+* `:menu_gchild:`
+
+  Same relationship to `menu_parent` as `menu_child`, but for a grandchild

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,6 +6,9 @@
 <body class="html front not-logged-in one-sidebar sidebar-first page-node " >
 {% include 'includes/top-hat.html' %}
 {% include 'includes/menu.html' %}
+<div id="skip-link">
+    <a href="#content" class="element-invisible element-focusable">Skip to main content</a>
+</div>
 <div class='row'>
     <div class='row span9'>
         {% block content %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,10 +5,6 @@
 </head>
 <body class="html front not-logged-in one-sidebar sidebar-first page-node " >
 {% include 'includes/top-hat.html' %}
-<!--  I'm not sure what this is here for
-    <div id="skip-link">
-    <a href="#content" class="element-invisible element-focusable">Skip to main content</a>
-    </div>-->
 {% include 'includes/menu.html' %}
 <div class='row'>
     <div class='row span9'>

--- a/templates/includes/footer.html
+++ b/templates/includes/footer.html
@@ -1,57 +1,50 @@
 <div id='footer'>
-    <div class='container'>
-        <div class='row'>
-            <div class='span2 contact'>
-                <h3>Contact Info</h3>
-                <div class="specific-contact">
-                    <!-- removed because we have no idea where $footer_message should be set
-                            -->
-                </div>
-                <div class="general-contact">
-                    <a href="http://oregonstate.edu/copyright">Copyright</a>
-                    &copy;2015              Oregon State University<br />
-                    <a href="http://oregonstate.edu/disclaimer">Disclaimer</a>
-                </div>
-                <div class="social-media"></div>
-            </div>
-            <div class='span10'>
-                <div class="region region-footer">
-                    <div id="block-menu-menu-footer-menu" class="block block-menu">
-
-
-                        <div class="content">
-                            <ul class="menu"><li class="first leaf"><a href="/" title="Go to homepage" class="active">Home</a></li>
-                                <li class="expanded"><a href="/about" title="">About</a><ul class="menu"><li class="first leaf"><a href="/about/people" class="submenu">Staff</a></li>
-                                    <li class="leaf"><a href="/about/employment">Employment</a></li>
-                                    <li class="leaf"><a href="/about/advisors" class="submenu">Advisors</a></li>
-                                    <li class="leaf"><a href="/about/logos" class="submenu">Logos</a></li>
-                                    <li class="last leaf"><a href="/contact">Contact</a></li>
-                                </ul></li>
-                                <li class="leaf"><a href="/blog" title="Blog">Blog</a></li>
-                                <li class="expanded"><a href="/services" title="">Services</a><ul class="menu"><li class="first leaf"><a href="/services/hosting" class="submenu">Hosting</a></li>
-                                    <li class="leaf"><a href="/services/development" class="submenu">Development</a></li>
-                                    <li class="leaf"><a href="/services/powerdev">OpenPOWER</a></li>
-                                    <li class="last leaf"><a href="/services/supercell" class="submenu">Supercell</a></li>
-                                </ul></li>
-                                <li class="last expanded"><a href="/donate">Donate</a><ul class="menu"><li class="first last leaf"><a href="/sponsors">Sponsors</a></li>
-                                </ul></li>
-                        </ul>  </div>
-                    </div>
-                    <div id="block-block-4" class="block block-block">
-
-
-                        <div class="content">
-                            <p>OSU Open Source Lab<br />
-                            Kerr Admin B211<br />
-                            Corvallis, OR 97331<br />
-                            General Inquiries:<br /><span style="color: #C34500;"><a href="mailto:info@osuosl.org">info@osuosl.org</a></span><br />
-                            Support for Project Infrastructure<br /><span style="color: #C34500;"><a href="mailto:support@osuosl.org">support@osuosl.org</a></span><br />
-                            Questions about Donations:<br /><span style="color: #C34500;"><a href="mailto:donations@osuosl.org">donations@osuosl.org</a></span></p>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
+<div class='container'>
+  <div class='row'>
+    <div class='span2 contact'>
+      <h3>Contact Info</h3>
+      <div class="content">
+        <p>OSU Open Source Lab<br />
+        Kerr Admin B211<br />
+        Corvallis, OR 97331<br />
+        General Inquiries:<br /><span style="color: #C34500;"><a href="mailto:info@osuosl.org">info@osuosl.org</a></span><br />
+        Support for Project Infrastructure<br /><span style="color: #C34500;"><a href="mailto:support@osuosl.org">support@osuosl.org</a></span><br />
+        Questions about Donations:<br /><span style="color: #C34500;"><a href="mailto:donations@osuosl.org">donations@osuosl.org</a></span></p>
+      </div>
+      <a href="http://oregonstate.edu/copyright">Copyright</a>
+      &copy;2015 Oregon State University<br />
+      <a href="http://oregonstate.edu/disclaimer">Disclaimer</a>
     </div>
+    <div class='span10'>
+      <div class="region region-footer">
+        <div id="block-menu-menu-footer-menu" class="block block-menu">
+          <div class="content">
+            <ul class="menu">
+              <li class="first leaf"><a href="/" title="Go to homepage" class="active">Home</a></li>
+              {% for page in pages | sort(attribute='order') %}
+              {% if page.top_menu == 'parent' %}
+              <li class="expanded"><a href='/{{ page.slug }}'>{{ page.title }}</a>
+                <ul>
+                  {% if page.duplicate_name %}
+                  <li class='leaf'><a href='/{{ page.slug }}'>{{ page.duplicate_name }}</a></li>
+                  {% endif %}
+                  {% for pchild in pages | sort(attribute='order') %}
+                  {% if pchild.menu_parent == page.menu_child %} 
+                  <li class="leaf"><a href='/{{ pchild.slug }}'>{{ pchild.title }}</a>     
+                    {% endif %}
+                    {% endfor %}
+                </ul>
+                  </li>
+                  {% elif page.top_menu%}
+                  <li><a href='/{{ page.slug }}'>{{ page.title }}</a></li>
+                  {% endif %}
+                  {% endfor %}
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
 </div>
 

--- a/templates/includes/footer.html
+++ b/templates/includes/footer.html
@@ -1,50 +1,48 @@
 <div id='footer'>
-<div class='container'>
-  <div class='row'>
-    <div class='span2 contact'>
-      <h3>Contact Info</h3>
-      <div class="content">
-        <p>OSU Open Source Lab<br />
-        Kerr Admin B211<br />
-        Corvallis, OR 97331<br />
-        General Inquiries:<br /><span style="color: #C34500;"><a href="mailto:info@osuosl.org">info@osuosl.org</a></span><br />
-        Support for Project Infrastructure<br /><span style="color: #C34500;"><a href="mailto:support@osuosl.org">support@osuosl.org</a></span><br />
-        Questions about Donations:<br /><span style="color: #C34500;"><a href="mailto:donations@osuosl.org">donations@osuosl.org</a></span></p>
-      </div>
-      <a href="http://oregonstate.edu/copyright">Copyright</a>
-      &copy;2015 Oregon State University<br />
-      <a href="http://oregonstate.edu/disclaimer">Disclaimer</a>
-    </div>
-    <div class='span10'>
-      <div class="region region-footer">
-        <div id="block-menu-menu-footer-menu" class="block block-menu">
-          <div class="content">
-            <ul class="menu">
-              <li class="first leaf"><a href="/" title="Go to homepage" class="active">Home</a></li>
-              {% for page in pages | sort(attribute='order') %}
-              {% if page.top_menu == 'parent' %}
-              <li class="expanded"><a href='/{{ page.slug }}'>{{ page.title }}</a>
-                <ul>
-                  {% if page.duplicate_name %}
-                  <li class='leaf'><a href='/{{ page.slug }}'>{{ page.duplicate_name }}</a></li>
-                  {% endif %}
-                  {% for pchild in pages | sort(attribute='order') %}
-                  {% if pchild.menu_parent == page.menu_child %} 
-                  <li class="leaf"><a href='/{{ pchild.slug }}'>{{ pchild.title }}</a>     
-                    {% endif %}
-                    {% endfor %}
-                </ul>
+  <div class='container'>
+    <div class='row'>
+      <div class='span2 contact'>
+        <h3>Contact Info</h3>
+        <div class="content">
+          <p>
+            OSU Open Source Lab<br />
+            Kerr Admin B211<br />
+            Corvallis, OR 97331<br />
+            General Inquiries:<br /><span style="color: #C34500;"><a href="mailto:info@osuosl.org">info@osuosl.org</a></span><br />
+            Support for Project Infrastructure<br /><span style="color: #C34500;"><a href="mailto:support@osuosl.org">support@osuosl.org</a></span><br />
+            Questions about Donations:<br /><span style="color: #C34500;"><a href="mailto:donations@osuosl.org">donations@osuosl.org</a></span>
+          </p>
+        </div>
+        <a href="http://oregonstate.edu/copyright">Copyright</a>
+        &copy;2015 Oregon State University<br />
+        <a href="http://oregonstate.edu/disclaimer">Disclaimer</a>
+        </div
+        <!-- Read the Pelican page list and create menu structure -->
+        {% set ptest = pages | menu_filter %}
+        <div class='span10'>
+          <div class="region region-footer">
+            <div id="block-menu-menu-footer-menu" class="block block-menu">
+              <div class="content">
+                <ul class="menu">
+                  <li class="first leaf"><a href="/" title="Go to homepage" class="active">Home</a></li>
+                  {% for page in ptest %}
+                  {% if page['children'] %}
+                  <li class="expanded"><a href={{ page['link'] }}>{{ page['name'] }}</a>
+                    <ul>
+                      {% for child in page['children'] %}
+                      <li class='leaf'><a href={{ child['link'] }}>{{ child['name'] }}</a></li>
+                      {% endfor %}
+                    </ul>
                   </li>
-                  {% elif page.top_menu%}
-                  <li><a href='/{{ page.slug }}'>{{ page.title }}</a></li>
+                  {% else %}
+                  <li class='leaf'><a href={{ page['link'] }}>{{ page['name'] }}</a></li>
                   {% endif %}
                   {% endfor %}
-            </ul>
+                </ul>
+              </div>
+            </div>
           </div>
         </div>
       </div>
     </div>
   </div>
-</div>
-</div>
-

--- a/templates/includes/footer.html
+++ b/templates/includes/footer.html
@@ -18,7 +18,7 @@
         <a href="http://oregonstate.edu/disclaimer">Disclaimer</a>
         </div
         <!-- Read the Pelican page list and create menu structure -->
-        {% set ptest = pages | menu_filter %}
+        {% set ptest = pages | menu_filter(DIRECT_TEMPLATE_INFO) %}
         <div class='span10'>
           <div class="region region-footer">
             <div id="block-menu-menu-footer-menu" class="block block-menu">

--- a/templates/includes/menu.html
+++ b/templates/includes/menu.html
@@ -5,7 +5,7 @@
 </div>
 
 <!-- Read the Pelican page list and create menu structure -->
-{% set pelpages = (pages | menu_filter) + DIRECT_TEMPLATE_INFO %}
+{% set pelpages = (pages | menu_filter(DIRECT_TEMPLATE_INFO)) %}
 
 <ul id="mobile-menu" role="navigation">
     <li id="mobile-main-menu">

--- a/templates/includes/menu.html
+++ b/templates/includes/menu.html
@@ -13,20 +13,10 @@
         <li class="first leaf"><a href="/" class="active">Home</a></li>
         {% for page in ptest %}
         {% if page['children'] %}
-        <li class="menuparent"><a href={{ page['link'] }}>{{ page['name'] }}</a>
+        <li class="expanded"><a href={{ page['link'] }}>{{ page['name'] }}</a>
           <ul>
             {% for child in page['children'] %}
-            {% if child['children'] %}
-            <li class="menuparent"><a href={{ child['link'] }}>{{ child['name'] }}</a>
-              <ul>
-                {% for grandchild in child['children'] %}
-                <li><a href={{ grandchild['link'] }}>{{ grandchild['name'] }}</a></li>
-                {% endfor %}
-              </ul>
-            </li>
-            {% else %}
-            <li><a href={{ child['link'] }}>{{ child['name'] }}</a></li>
-            {% endif %}
+            <li class="leaf"><a href={{ child['link'] }}>{{ child['name'] }}</a></li>
             {% endfor %}
           </ul>
         </li>

--- a/templates/includes/menu.html
+++ b/templates/includes/menu.html
@@ -52,10 +52,21 @@
         <label class='menu-button' for='check'>Menu</label>
     <ul>
         <li><a href='{{ SITEURL }}'>Home</a></li>
-        {% for page in pages |sort(attribute="order")%}
-        {% if page.type == 'page' %}
-        <li><a href='#{{ page.slug }}'>{{ page.title }}</a></li>
-        {% endif %}
+        {% for page in pages | sort(attribute="order") %}
+          {% if page.menu == 'parent' %}
+            <li><a href='#{{ page.slug }}'>{{ page.title }}</a></li>
+          {% endif %}
+
+          {% if page.menu_child %}
+            <ul>
+            {% for pchild in pages | sort(attribute="order") %}
+              {% if pchild.menu_parent == page.menu_child %}
+                  <li> <!-- DO SOMETHING --> </li> 
+              {% endif %}
+            {% endfor %}
+            </ul>
+          {% endif %}
+
         {% endfor %}
         <li><a href='#schedule'>Schedule <span class='arrow'>&#9660;<span></a>
                 <ul>

--- a/templates/includes/menu.html
+++ b/templates/includes/menu.html
@@ -1,21 +1,64 @@
 <div id='page-wrapper' class='container'>
-<div id='header' class='row-fluid'>
+  <div id='header' class='row-fluid'>
     <a class="parent" href='http://eecs.oregonstate.edu'>School of Electrical Engineering and Computer Science</a>
     <h1><a href='/'>{{ SITENAME }}</a></h1>
-</div>
+  </div>
 
-{% set ptest = pages | menu_filter %}
+  <!-- Read the Pelican page list and create menu structure -->
+  {% set ptest = pages | menu_filter %}
 
-<ul id="mobile-menu" role="navigation">
+  <ul id="mobile-menu" role="navigation">
     <li id="mobile-main-menu">
-        <ul class="menu">
-            <li class="first leaf"><a href="/" class="active">Home</a></li>
+      <ul class="menu">
+        <li class="first leaf"><a href="/" class="active">Home</a></li>
+        {% for page in ptest %}
+        {% if page['children'] %}
+        <li class="menuparent"><a href={{ page['link'] }}>{{ page['name'] }}</a>
+          <ul>
+            {% for child in page['children'] %}
+            {% if child['children'] %}
+            <li class="menuparent"><a href={{ child['link'] }}>{{ child['name'] }}</a>
+              <ul>
+                {% for grandchild in child['children'] %}
+                <li><a href={{ grandchild['link'] }}>{{ grandchild['name'] }}</a></li>
+                {% endfor %}
+              </ul>
+            </li>
+            {% else %}
+            <li><a href={{ child['link'] }}>{{ child['name'] }}</a></li>
+            {% endif %}
+            {% endfor %}
+          </ul>
+        </li>
+        {% else %}
+        <li><a href={{ page['link'] }}>{{ page['name'] }}</a></li>
+        {% endif %}
+        {% endfor %}
+      </ul>
+    </li>
+    <li id="mobile-osu-top-hat">
+      <ul class="menu">
+        <li class="first leaf"><a href="http://calendar.oregonstate.edu">Calendar</a></li>
+        <li class="leaf"><a href="http://osulibrary.oregonstate.edu">Library</a></li>
+        <li class="leaf"><a href="http://oregonstate.edu/campusmap">Maps</a></li>
+        <li class="leaf"><a href="http://oregonstate.edu/main/online-services">Online Services</a></li>
+        <li class="last leaf"><a href="https://securelb.imodules.com/s/359/campaign/index.aspx?sid=359&amp;gid=34&amp;pgid=1982&amp;cid=3007" class="campaign">Make a Gift</a></li>
+      </ul>
+    </li>
+  </ul>
+  <!-- Main menu navbar -->
+  <div id='main-menu' role='navigation'>
+    <div class="region region-nav">
+      <div id="block-nice-menus-1" class="block block-nice-menus">
+        <div class="content">
+          <ul class="nice-menu nice-menu-down nice-menu-main-menu" id="nice-menu-1">
+            <li class="menu-217 menu-path-front first odd"><a href='/' class="active">Home</a></li>
             {% for page in ptest %}
             {% if page['children'] %}
             <li class="menuparent"><a href={{ page['link'] }}>{{ page['name'] }}</a>
               <ul>
-              {% for child in page['children'] %}
-              {% if child['children'] %}
+                {% for child in page['children'] %}
+                {% if child['children'] %}
                 <li class="menuparent"><a href={{ child['link'] }}>{{ child['name'] }}</a>
                   <ul>
                     {% for grandchild in child['children'] %}
@@ -23,61 +66,19 @@
                     {% endfor %}
                   </ul>
                 </li>
-              {% else %}
+                {% else %}
                 <li><a href={{ child['link'] }}>{{ child['name'] }}</a></li>
-              {% endif %}
-              {% endfor %}
+                {% endif %}
+                {% endfor %}
               </ul>
             </li>
             {% else %}
             <li><a href={{ page['link'] }}>{{ page['name'] }}</a></li>
             {% endif %}
             {% endfor %}
-        </ul>
-    </li>
-    <li id="mobile-osu-top-hat">
-        <ul class="menu">
-            <li class="first leaf"><a href="http://calendar.oregonstate.edu">Calendar</a></li>
-            <li class="leaf"><a href="http://osulibrary.oregonstate.edu">Library</a></li>
-            <li class="leaf"><a href="http://oregonstate.edu/campusmap">Maps</a></li>
-            <li class="leaf"><a href="http://oregonstate.edu/main/online-services">Online Services</a></li>
-            <li class="last leaf"><a href="https://securelb.imodules.com/s/359/campaign/index.aspx?sid=359&amp;gid=34&amp;pgid=1982&amp;cid=3007" class="campaign">Make a Gift</a></li>
-        </ul>
-    </li>
-</ul>
-<!-- Main menu navbar -->
-<div id='main-menu' role='navigation'>
-    <div class="region region-nav">
-        <div id="block-nice-menus-1" class="block block-nice-menus">
-            <div class="content">
-                <ul class="nice-menu nice-menu-down nice-menu-main-menu" id="nice-menu-1">
-                    <li class="menu-217 menu-path-front first odd"><a href='/' class="active">Home</a></li>
-                    {% for page in ptest %}
-                    {% if page['children'] %}
-                    <li class="menuparent"><a href={{ page['link'] }}>{{ page['name'] }}</a>
-                      <ul>
-                      {% for child in page['children'] %}
-                      {% if child['children'] %}
-                        <li class="menuparent"><a href={{ child['link'] }}>{{ child['name'] }}</a>
-                          <ul>
-                            {% for grandchild in child['children'] %}
-                            <li><a href={{ grandchild['link'] }}>{{ grandchild['name'] }}</a></li>
-                            {% endfor %}
-                          </ul>
-                        </li>
-                      {% else %}
-                        <li><a href={{ child['link'] }}>{{ child['name'] }}</a></li>
-                      {% endif %}
-                      {% endfor %}
-                      </ul>
-                    </li>
-                    {% else %}
-                    <li><a href={{ page['link'] }}>{{ page['name'] }}</a></li>
-                    {% endif %}
-                    {% endfor %}
-                </ul>
-            </div>
+          </ul>
         </div>
+      </div>
     </div>
-</div>
+  </div>
 <!-- /#main-menu -->

--- a/templates/includes/menu.html
+++ b/templates/includes/menu.html
@@ -3,46 +3,36 @@
     <a class="parent" href='http://eecs.oregonstate.edu'>School of Electrical Engineering and Computer Science</a>
     <h1><a href='/'>{{ SITENAME }}</a></h1>
 </div>
+
+{% set ptest = pages | menu_filter %}
+
 <ul id="mobile-menu" role="navigation">
     <li id="mobile-main-menu">
         <ul class="menu">
             <li class="first leaf"><a href="/" class="active">Home</a></li>
-            {% for page in pages | sort(attribute='order') %}
-            {% if page.top_menu == 'parent' %}
-            <li class="menuparent"><a href='/{{ page.slug }}'>{{ page.title }}</a>
-                <ul>
-                    {% if page.duplicate_name %}
-                    <li><a href='/{{ page.slug }}'>{{ page.duplicate_name }}</a></li>
-                    {% endif %}
-                    <!-- If page has a child, create a list then inspect each page to see
-                        if it is a child of this page, then write to html -->
-                        {% for pchild in pages | sort(attribute='order') %}
-                        {% if pchild.menu_parent == page.menu_child and not pchild.menu_gchild %}
-                        <li><a href='/{{ pchild.slug }}'>{{ pchild.title }}</a></li>
-                        {% elif pchild.menu_parent == page.menu_child %}
-                        <li class="menuparent"><a href='/{{ pchild.slug }}'>{{ pchild.title }}</a>
-                            <!-- If child has a child (gchild), create a list then inspect
-                                each page to see if it is a child of this page, then write
-                                to html -->
-                                {% if pchild.menu_gchild %}
-                                <ul>
-                                    {% for pgchild in pages | sort(attribute='order') %}
-                                    {% if pgchild.menu_parent == pchild.menu_gchild %}
-                                    <li><a href='/{{ pgchild.slug }}'>{{ pgchild.title }}</a></li>
-                                    {% endif %}
-                                    {% endfor %}
-                                </ul>
-                        </li>
-                        {% endif %}
-                        {% endif %}
-                        {% endfor %}
-                </ul>
+            {% for page in ptest %}
+            {% if page['children'] %}
+            <li class="menuparent"><a href={{ page['link'] }}>{{ page['name'] }}</a>
+              <ul>
+              {% for child in page['children'] %}
+              {% if child['children'] %}
+                <li class="menuparent"><a href={{ child['link'] }}>{{ child['name'] }}</a>
+                  <ul>
+                    {% for grandchild in child['children'] %}
+                    <li><a href={{ grandchild['link'] }}>{{ grandchild['name'] }}</a></li>
+                    {% endfor %}
+                  </ul>
+                </li>
+              {% else %}
+                <li><a href={{ child['link'] }}>{{ child['name'] }}</a></li>
+              {% endif %}
+              {% endfor %}
+              </ul>
             </li>
-            {% elif page.top_menu%}
-            <li><a href='/{{ page.slug }}'>{{ page.title }}</a></li>
+            {% else %}
+            <li><a href={{ page['link'] }}>{{ page['name'] }}</a></li>
             {% endif %}
             {% endfor %}
-
         </ul>
     </li>
     <li id="mobile-osu-top-hat">
@@ -62,42 +52,29 @@
             <div class="content">
                 <ul class="nice-menu nice-menu-down nice-menu-main-menu" id="nice-menu-1">
                     <li class="menu-217 menu-path-front first odd"><a href='/' class="active">Home</a></li>
-                    {% for page in pages | sort(attribute='order') %}
-                    {% if page.top_menu == 'parent' %}
-                    <li class="menuparent"><a href='/{{ page.slug }}'>{{ page.title }}</a>
-                        <ul>
-                            {% if page.duplicate_name %}
-                            <li><a href='/{{ page.slug }}'>{{ page.duplicate_name }}</a></li>
-                            {% endif %}
-                            <!-- If page has a child, create a list then inspect each page to see
-                                if it is a child of this page, then write to html -->
-                                {% for pchild in pages | sort(attribute='order') %}
-                                {% if pchild.menu_parent == page.menu_child and not pchild.menu_gchild %}
-                                <li><a href='/{{ pchild.slug }}'>{{ pchild.title }}</a></li>
-                                {% elif pchild.menu_parent == page.menu_child %}
-                                <li class="menuparent"><a href='/{{ pchild.slug }}'>{{ pchild.title }}</a>
-                                    <!-- If child has a child (gchild), create a list then inspect
-                                        each page to see if it is a child of this page, then write
-                                        to html -->
-                                        {% if pchild.menu_gchild %}
-                                        <ul>
-                                            {% for pgchild in pages | sort(attribute='order') %}
-                                            {% if pgchild.menu_parent == pchild.menu_gchild %}
-                                            <li><a href='/{{ pgchild.slug }}'>{{ pgchild.title }}</a></li>
-                                            {% endif %}
-                                            {% endfor %}
-                                        </ul>
-                                </li>
-                                {% endif %}
-                                {% endif %}
-                                {% endfor %}
-                        </ul>
+                    {% for page in ptest %}
+                    {% if page['children'] %}
+                    <li class="menuparent"><a href={{ page['link'] }}>{{ page['name'] }}</a>
+                      <ul>
+                      {% for child in page['children'] %}
+                      {% if child['children'] %}
+                        <li class="menuparent"><a href={{ child['link'] }}>{{ child['name'] }}</a>
+                          <ul>
+                            {% for grandchild in child['children'] %}
+                            <li><a href={{ grandchild['link'] }}>{{ grandchild['name'] }}</a></li>
+                            {% endfor %}
+                          </ul>
+                        </li>
+                      {% else %}
+                        <li><a href={{ child['link'] }}>{{ child['name'] }}</a></li>
+                      {% endif %}
+                      {% endfor %}
+                      </ul>
                     </li>
-                    {% elif page.top_menu%}
-                    <li><a href='/{{ page.slug }}'>{{ page.title }}</a></li>
+                    {% else %}
+                    <li><a href={{ page['link'] }}>{{ page['name'] }}</a></li>
                     {% endif %}
                     {% endfor %}
-
                 </ul>
             </div>
         </div>

--- a/templates/includes/menu.html
+++ b/templates/includes/menu.html
@@ -52,42 +52,38 @@
     <div id="block-nice-menus-1" class="block block-nice-menus">
       <div class="content">
         <ul class="nice-menu nice-menu-down nice-menu-main-menu" id="nice-menu-1">
-          <li><a href='{{ SITEURL }}'>Home</a></li>
-          {% for page in pages | sort(attribute="order") %}
-            {% if page.menu == 'parent' %}
-              <li class="menuparent"><a href='#{{ page.slug }}'>{{ page.title }}</a></li>
-            {% elif page.menu %}
-              <li><a href='#{{ page.slug }}'>{{ page.title }}</a></li>
-            {% endif %}
-
+          <li class="menu-217 menu-path-front first odd"><a href='/' class="active">Home</a></li>
+          {% for page in pages | sort(attribute='order') %}
+            {% if page.top_menu == 'parent' %}
+              <li class="menuparent"><a href='/{{ page.slug }}'>{{ page.title }}</a>
             <!-- If page has a child, create a list then inspect each page to see
                  if it is a child of this page, then write to html -->
-            {% if page.menu_child %}
               <ul>
-              {% for pchild in pages | sort(attribute="order") %}
-                {% if pchild.menu_parent == page.menu_child and pchild.menu_gchild %}
-                  <li class="menuparent"><a href='#{{ page.slug }}'>{{ page.title }}</a></li>
+              {% for pchild in pages | sort(attribute='order') %}
+                {% if pchild.menu_parent == page.menu_child and not pchild.menu_gchild %}
+                  <li><a href='/{{ pchild.slug }}'>{{ pchild.title }}</a></li>
                 {% elif pchild.menu_parent == page.menu_child %}
-                  <li><a href='#{{ page.slug }}'>{{ page.title }}</a></li>
-
+                  <li class="menuparent"><a href='/{{ pchild.slug }}'>{{ pchild.title }}</a>
                   <!-- If child has a child (gchild), create a list then inspect
                        each page to see if it is a child of this page, then write
                        to html -->
                   {% if pchild.menu_gchild %}
                     <ul>
-                    {% for pgchild in pages | sort(attribute="order") %}
+                    {% for pgchild in pages | sort(attribute='order') %}
                       {% if pgchild.menu_parent == pchild.menu_gchild %}
-                        <li><a href='#{{ page.slug }}'>{{ page.title }}</a></li>
+                        <li><a href='/{{ pgchild.slug }}'>{{ pgchild.title }}</a></li>
                       {% endif %}
                     {% endfor %}
                    </ul>
+                   </li>
                   {% endif %}
-
                 {% endif %}
               {% endfor %}
               </ul>
+              </li>
+            {% elif page.top_menu%}
+              <li><a href='/{{ page.slug }}'>{{ page.title }}</a></li>
             {% endif %}
-
           {% endfor %}
 
         </ul>

--- a/templates/includes/menu.html
+++ b/templates/includes/menu.html
@@ -47,72 +47,25 @@
 </li>
 </ul>
 <!-- Main menu navbar -->
-<div id='main-menu' role="navigation">
-    <div class="region region-nav">
-        <div id="block-nice-menus-1" class="block block-nice-menus">
-            <div class="content">
-                <ul class="nice-menu nice-menu-down nice-menu-main-menu" id="nice-menu-1">
-                    <li class="menu-217 menu-path-front first odd "><a href="/" class="active">Home</a></li>
-                    <li class="menu-452 menuparent  menu-path-node-17  even "><a href="/about">About</a>
-                        <ul>
-                            <li class="menu-1851 menu-path-node-17 first odd "><a href="/about">Summary</a></li>
-                            <li class="menu-1786 menu-path-node-28  odd "><a href="/about/logos">Open Source Lab logos</a></li>
-                            <li class="menu-1846 menu-path-node-559  even last"><a href="/donate/faq">FAQ</a></li>
-                        </ul>
-                    </li>
-                    <li class="menu-452 menuparent  menu-path-node-17  even "><a href="/about/people">Organization</a>
-                        <ul>
-                            <li class="menu-730 menu-path-about-people  even "><a href="/about/people">Staff</a></li>
-                            <li class="menu-1826 menu-path-node-106  odd "><a href="/about/advisors">Advisory Board</a></li>
-                        </ul>
-                    </li>
-                    <li class="menu-1796 menuparent  menu-path-node-103  even "><a href="/services">Services</a>
-                        <ul>
-                            <li class="menu-1791 menuparent  menu-path-node-115 first odd "><a href="/services/hosting">Hosting</a>
-                                <ul>
-                                    <li class="menu-1006 menu-path-communities first odd "><a href="/communities">Hosted Projects</a></li>
-                                    <li class="menu-1018 menu-path-node-541  even "><a href="/services/hosting/details">Hosting Details</a></li>
-                                    <li class="menu-1021 menu-path-node-544  odd"><a href="/services/hosting/policy">Hosting Policy</a></li>
-                                    <li class="menu-937 menu-path-node-535  even last "><a href="/request-hosting">Request Hosting</a></li>
-                                </ul>
-                            </li>
-                            <li class="menu-676 menu-path-node-118  even "><a href="/services/development">Development</a></li>
-                            <li class="menu-2366 menuparent  menu-path-node-1091  even "><a href="/services/powerdev">Development Hosting</a>
-                                <ul>
-                                    <li class="menu-2371 menu-path-node-1086 first odd last"><a href="/services/powerdev/request_hosting">PowerLinux / OpenPOWER Request Form</a></li>
-                                </ul>
-                            </li>
-                            <li class="menu-829 menuparent  menu-path-node-517  odd last"><a href="/services/supercell">Supercell</a>
-                                <ul>
-                                    <li class="menu-925 menu-path-node-526 first odd "><a href="/services/supercell/request">Feedback Form</a></li>
-                                    <li class="menu-1027 menu-path-node-577  even last"><a href="/services/supercell/sponsors" title="">Sponsors</a></li>
-                                </ul>
-                            </li>
-                        </ul>
-                    </li>
-                    <li class="menu-452 menuparent  menu-path-node-17  even "><a href="/students">Student Experience</a>
-                        <ul>
-                            <li class="menu-2066 menu-path-about-employment  odd first"><a href="/about/employment">Employment</a></li>
-                            <li class="menu-1816 menu-path-node-1016  even "><a href="/devops-bootcamp">DevOps BootCamp</a></li>
-                            <li class="menu-1836 menu-path-node-726  odd "><a href="http://wiki.osuosl.org/gsoc/">GSoC</a></li>
-                            <li class="menu-1836 menu-path-node-726  even last "><a href="http://beaverbarcamp.org">Beaver Barcamp</a></li>
-                        </ul>
-                    </li>
-                    <li class="menu-344 menu-path-blog  odd "><a href="/blog">Blog</a></li>
-                    <li class="menu-1039 menuparent  menu-path-node-22  even last"><a href="/contact">Contact Us</a>
-                        <ul>
-                            <li class="menu-1791 menu-path-node-115 first odd "><a href="/contact">Contact</a></li>
-                            <li class="menu-1039 menuparent  menu-path-node-22  even last"><a href="/donate">Donate</a>
-                                <ul>
-                                    <li class="menu-1821 menu-path-node-538 first odd "><a href="/sponsors">Sponsors</a></li>
-                                    <li class="menu-1841 menu-path-node-133  even last"><a href="/donate/why-do-we-give-osuosl">Why Do We Give to the OSL?</a></li>
-                                </ul>
-                            </li>
-                        </ul>
-                    </li>
+<div class='main-menu'>
+        <input id='check' type=checkbox></input>
+        <label class='menu-button' for='check'>Menu</label>
+    <ul>
+        <li><a href='{{ SITEURL }}'>Home</a></li>
+        {% for page in pages |sort(attribute="order")%}
+        {% if page.type == 'page' %}
+        <li><a href='#{{ page.slug }}'>{{ page.title }}</a></li>
+        {% endif %}
+        {% endfor %}
+        <li><a href='#schedule'>Schedule <span class='arrow'>&#9660;<span></a>
+                <ul>
+                    {% for p in pages |sort(attribute="order")%}
+                    {% if p.type == 'schedule' %}
+                    <li><a href='#{{ p.slug }}'>{{ p.title }}</a></li>
+                    {% endif %}
+                    {% endfor %}
                 </ul>
-            </div>
+                </li>
+            </ul>
         </div>
-    </div>
-</div>
 <!-- /#main-menu -->

--- a/templates/includes/menu.html
+++ b/templates/includes/menu.html
@@ -56,9 +56,12 @@
           {% for page in pages | sort(attribute='order') %}
             {% if page.top_menu == 'parent' %}
               <li class="menuparent"><a href='/{{ page.slug }}'>{{ page.title }}</a>
+              <ul>
+              {% if page.duplicate_name %}
+                <li><a href='/{{ page.slug }}'>{{ page.duplicate_name }}</a></li>
+              {% endif %}
             <!-- If page has a child, create a list then inspect each page to see
                  if it is a child of this page, then write to html -->
-              <ul>
               {% for pchild in pages | sort(attribute='order') %}
                 {% if pchild.menu_parent == page.menu_child and not pchild.menu_gchild %}
                   <li><a href='/{{ pchild.slug }}'>{{ pchild.title }}</a></li>

--- a/templates/includes/menu.html
+++ b/templates/includes/menu.html
@@ -1,97 +1,106 @@
 <div id='page-wrapper' class='container'>
-    <div id='header' class='row-fluid'>
-        <a class="parent" href='http://eecs.oregonstate.edu'>School of Electrical Engineering and Computer Science</a>
-        <h1><a href='/'>OSU Open Source Lab</a></h1>
-    </div>
+<div id='header' class='row-fluid'>
+    <a class="parent" href='http://eecs.oregonstate.edu'>School of Electrical Engineering and Computer Science</a>
+    <h1><a href='/'>{{ SITENAME }}</a></h1>
+</div>
 <ul id="mobile-menu" role="navigation">
     <li id="mobile-main-menu">
         <ul class="menu">
             <li class="first leaf"><a href="/" class="active">Home</a></li>
-            <li class="expanded"><a href="/about">About Us</a><ul class="menu"><li class="first collapsed"><a href="/about">Summary</a></li>
-            <li class="leaf"><a href="/about/people">Staff</a></li>
-            <li class="leaf"><a href="/about/employment">Employment</a></li>
-            <li class="leaf"><a href="/devopsbootcamp">DevOps BootCamp</a></li>
-            <li class="leaf"><a href="/about/advisors">Advisors</a></li>
-            <li class="leaf"><a href="/contact">Contact</a></li>
-            <li class="leaf"><a href="/about/logos">Open Source Lab logos</a></li>
-            <li class="last leaf"><a href="/about/goscon">GOSCON</a></li>
+            {% for page in pages | sort(attribute='order') %}
+            {% if page.top_menu == 'parent' %}
+            <li class="menuparent"><a href='/{{ page.slug }}'>{{ page.title }}</a>
+                <ul>
+                    {% if page.duplicate_name %}
+                    <li><a href='/{{ page.slug }}'>{{ page.duplicate_name }}</a></li>
+                    {% endif %}
+                    <!-- If page has a child, create a list then inspect each page to see
+                        if it is a child of this page, then write to html -->
+                        {% for pchild in pages | sort(attribute='order') %}
+                        {% if pchild.menu_parent == page.menu_child and not pchild.menu_gchild %}
+                        <li><a href='/{{ pchild.slug }}'>{{ pchild.title }}</a></li>
+                        {% elif pchild.menu_parent == page.menu_child %}
+                        <li class="menuparent"><a href='/{{ pchild.slug }}'>{{ pchild.title }}</a>
+                            <!-- If child has a child (gchild), create a list then inspect
+                                each page to see if it is a child of this page, then write
+                                to html -->
+                                {% if pchild.menu_gchild %}
+                                <ul>
+                                    {% for pgchild in pages | sort(attribute='order') %}
+                                    {% if pgchild.menu_parent == pchild.menu_gchild %}
+                                    <li><a href='/{{ pgchild.slug }}'>{{ pgchild.title }}</a></li>
+                                    {% endif %}
+                                    {% endfor %}
+                                </ul>
+                        </li>
+                        {% endif %}
+                        {% endif %}
+                        {% endfor %}
+                </ul>
+            </li>
+            {% elif page.top_menu%}
+            <li><a href='/{{ page.slug }}'>{{ page.title }}</a></li>
+            {% endif %}
+            {% endfor %}
+
         </ul>
     </li>
-    <li class="leaf"><a href="/blog">Blog</a></li>
-    <li class="expanded"><a href="/services">Services</a>
+    <li id="mobile-osu-top-hat">
         <ul class="menu">
-            <li class="first collapsed"><a href="/services/hosting">Hosting</a></li>
-            <li class="leaf"><a href="/services/development">Development</a></li>
-            <li class="collapsed"><a href="/request-hosting">Request Hosting</a></li>
-            <li class="collapsed"><a href="/services/powerdev">PowerLinux / OpenPOWER Development Hosting</a></li>
-            <li class="last collapsed"><a href="/services/supercell">Supercell</a></li>
+            <li class="first leaf"><a href="http://calendar.oregonstate.edu">Calendar</a></li>
+            <li class="leaf"><a href="http://osulibrary.oregonstate.edu">Library</a></li>
+            <li class="leaf"><a href="http://oregonstate.edu/campusmap">Maps</a></li>
+            <li class="leaf"><a href="http://oregonstate.edu/main/online-services">Online Services</a></li>
+            <li class="last leaf"><a href="https://securelb.imodules.com/s/359/campaign/index.aspx?sid=359&amp;gid=34&amp;pgid=1982&amp;cid=3007" class="campaign">Make a Gift</a></li>
         </ul>
     </li>
-    <li class="leaf"><a href="wiki.osuosl.org/gsoc/">GSoC</a></li>
-    <li class="last expanded"><a href="/donate">Donate</a>
-        <ul class="menu">
-            <li class="first leaf"><a href="/sponsors">Sponsors</a></li>
-            <li class="last leaf"><a href="/donate/why-do-we-give-osuosl">Why Do We Give to the OSL?</a></li>
-        </ul>
-    </li>
-</ul>
-</li>
-<li id="mobile-osu-top-hat">
-    <ul class="menu">
-        <li class="first leaf"><a href="http://calendar.oregonstate.edu">Calendar</a></li>
-        <li class="leaf"><a href="http://osulibrary.oregonstate.edu">Library</a></li>
-        <li class="leaf"><a href="http://oregonstate.edu/campusmap">Maps</a></li>
-        <li class="leaf"><a href="http://oregonstate.edu/main/online-services">Online Services</a></li>
-        <li class="last leaf"><a href="https://securelb.imodules.com/s/359/campaign/index.aspx?sid=359&amp;gid=34&amp;pgid=1982&amp;cid=3007" class="campaign">Make a Gift</a></li>
-    </ul>
-</li>
 </ul>
 <!-- Main menu navbar -->
 <div id='main-menu' role='navigation'>
-  <div class="region region-nav">
-    <div id="block-nice-menus-1" class="block block-nice-menus">
-      <div class="content">
-        <ul class="nice-menu nice-menu-down nice-menu-main-menu" id="nice-menu-1">
-          <li class="menu-217 menu-path-front first odd"><a href='/' class="active">Home</a></li>
-          {% for page in pages | sort(attribute='order') %}
-            {% if page.top_menu == 'parent' %}
-              <li class="menuparent"><a href='/{{ page.slug }}'>{{ page.title }}</a>
-              <ul>
-              {% if page.duplicate_name %}
-                <li><a href='/{{ page.slug }}'>{{ page.duplicate_name }}</a></li>
-              {% endif %}
-            <!-- If page has a child, create a list then inspect each page to see
-                 if it is a child of this page, then write to html -->
-              {% for pchild in pages | sort(attribute='order') %}
-                {% if pchild.menu_parent == page.menu_child and not pchild.menu_gchild %}
-                  <li><a href='/{{ pchild.slug }}'>{{ pchild.title }}</a></li>
-                {% elif pchild.menu_parent == page.menu_child %}
-                  <li class="menuparent"><a href='/{{ pchild.slug }}'>{{ pchild.title }}</a>
-                  <!-- If child has a child (gchild), create a list then inspect
-                       each page to see if it is a child of this page, then write
-                       to html -->
-                  {% if pchild.menu_gchild %}
-                    <ul>
-                    {% for pgchild in pages | sort(attribute='order') %}
-                      {% if pgchild.menu_parent == pchild.menu_gchild %}
-                        <li><a href='/{{ pgchild.slug }}'>{{ pgchild.title }}</a></li>
-                      {% endif %}
+    <div class="region region-nav">
+        <div id="block-nice-menus-1" class="block block-nice-menus">
+            <div class="content">
+                <ul class="nice-menu nice-menu-down nice-menu-main-menu" id="nice-menu-1">
+                    <li class="menu-217 menu-path-front first odd"><a href='/' class="active">Home</a></li>
+                    {% for page in pages | sort(attribute='order') %}
+                    {% if page.top_menu == 'parent' %}
+                    <li class="menuparent"><a href='/{{ page.slug }}'>{{ page.title }}</a>
+                        <ul>
+                            {% if page.duplicate_name %}
+                            <li><a href='/{{ page.slug }}'>{{ page.duplicate_name }}</a></li>
+                            {% endif %}
+                            <!-- If page has a child, create a list then inspect each page to see
+                                if it is a child of this page, then write to html -->
+                                {% for pchild in pages | sort(attribute='order') %}
+                                {% if pchild.menu_parent == page.menu_child and not pchild.menu_gchild %}
+                                <li><a href='/{{ pchild.slug }}'>{{ pchild.title }}</a></li>
+                                {% elif pchild.menu_parent == page.menu_child %}
+                                <li class="menuparent"><a href='/{{ pchild.slug }}'>{{ pchild.title }}</a>
+                                    <!-- If child has a child (gchild), create a list then inspect
+                                        each page to see if it is a child of this page, then write
+                                        to html -->
+                                        {% if pchild.menu_gchild %}
+                                        <ul>
+                                            {% for pgchild in pages | sort(attribute='order') %}
+                                            {% if pgchild.menu_parent == pchild.menu_gchild %}
+                                            <li><a href='/{{ pgchild.slug }}'>{{ pgchild.title }}</a></li>
+                                            {% endif %}
+                                            {% endfor %}
+                                        </ul>
+                                </li>
+                                {% endif %}
+                                {% endif %}
+                                {% endfor %}
+                        </ul>
+                    </li>
+                    {% elif page.top_menu%}
+                    <li><a href='/{{ page.slug }}'>{{ page.title }}</a></li>
+                    {% endif %}
                     {% endfor %}
-                   </ul>
-                   </li>
-                  {% endif %}
-                {% endif %}
-              {% endfor %}
-              </ul>
-              </li>
-            {% elif page.top_menu%}
-              <li><a href='/{{ page.slug }}'>{{ page.title }}</a></li>
-            {% endif %}
-          {% endfor %}
 
-        </ul>
-      </div>
+                </ul>
+            </div>
+        </div>
     </div>
-  </div>
 </div>
 <!-- /#main-menu -->

--- a/templates/includes/menu.html
+++ b/templates/includes/menu.html
@@ -5,13 +5,13 @@
   </div>
 
   <!-- Read the Pelican page list and create menu structure -->
-  {% set ptest = pages | menu_filter %}
+  {% set pelpages = pages | menu_filter %}
 
   <ul id="mobile-menu" role="navigation">
     <li id="mobile-main-menu">
       <ul class="menu">
         <li class="first leaf"><a href="/" class="active">Home</a></li>
-        {% for page in ptest %}
+        {% for page in pelpages %}
         {% if page['children'] %}
         <li class="expanded"><a href={{ page['link'] }}>{{ page['name'] }}</a>
           <ul>
@@ -43,7 +43,7 @@
         <div class="content">
           <ul class="nice-menu nice-menu-down nice-menu-main-menu" id="nice-menu-1">
             <li class="menu-217 menu-path-front first odd"><a href='/' class="active">Home</a></li>
-            {% for page in ptest %}
+            {% for page in pelpages %}
             {% if page['children'] %}
             <li class="menuparent"><a href={{ page['link'] }}>{{ page['name'] }}</a>
               <ul>

--- a/templates/includes/menu.html
+++ b/templates/includes/menu.html
@@ -47,36 +47,52 @@
 </li>
 </ul>
 <!-- Main menu navbar -->
-<div class='main-menu'>
-        <input id='check' type=checkbox></input>
-        <label class='menu-button' for='check'>Menu</label>
-    <ul>
-        <li><a href='{{ SITEURL }}'>Home</a></li>
-        {% for page in pages | sort(attribute="order") %}
-          {% if page.menu == 'parent' %}
-            <li><a href='#{{ page.slug }}'>{{ page.title }}</a></li>
-          {% endif %}
+<div id='main-menu' role='navigation'>
+  <div class="region region-nav">
+    <div id="block-nice-menus-1" class="block block-nice-menus">
+      <div class="content">
+        <ul class="nice-menu nice-menu-down nice-menu-main-menu" id="nice-menu-1">
+          <li><a href='{{ SITEURL }}'>Home</a></li>
+          {% for page in pages | sort(attribute="order") %}
+            {% if page.menu == 'parent' %}
+              <li class="menuparent"><a href='#{{ page.slug }}'>{{ page.title }}</a></li>
+            {% elif page.menu %}
+              <li><a href='#{{ page.slug }}'>{{ page.title }}</a></li>
+            {% endif %}
 
-          {% if page.menu_child %}
-            <ul>
-            {% for pchild in pages | sort(attribute="order") %}
-              {% if pchild.menu_parent == page.menu_child %}
-                  <li> <!-- DO SOMETHING --> </li> 
-              {% endif %}
-            {% endfor %}
-            </ul>
-          {% endif %}
+            <!-- If page has a child, create a list then inspect each page to see
+                 if it is a child of this page, then write to html -->
+            {% if page.menu_child %}
+              <ul>
+              {% for pchild in pages | sort(attribute="order") %}
+                {% if pchild.menu_parent == page.menu_child and pchild.menu_gchild %}
+                  <li class="menuparent"><a href='#{{ page.slug }}'>{{ page.title }}</a></li>
+                {% elif pchild.menu_parent == page.menu_child %}
+                  <li><a href='#{{ page.slug }}'>{{ page.title }}</a></li>
 
-        {% endfor %}
-        <li><a href='#schedule'>Schedule <span class='arrow'>&#9660;<span></a>
-                <ul>
-                    {% for p in pages |sort(attribute="order")%}
-                    {% if p.type == 'schedule' %}
-                    <li><a href='#{{ p.slug }}'>{{ p.title }}</a></li>
-                    {% endif %}
+                  <!-- If child has a child (gchild), create a list then inspect
+                       each page to see if it is a child of this page, then write
+                       to html -->
+                  {% if pchild.menu_gchild %}
+                    <ul>
+                    {% for pgchild in pages | sort(attribute="order") %}
+                      {% if pgchild.menu_parent == pchild.menu_gchild %}
+                        <li><a href='#{{ page.slug }}'>{{ page.title }}</a></li>
+                      {% endif %}
                     {% endfor %}
-                </ul>
-                </li>
-            </ul>
-        </div>
+                   </ul>
+                  {% endif %}
+
+                {% endif %}
+              {% endfor %}
+              </ul>
+            {% endif %}
+
+          {% endfor %}
+
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
 <!-- /#main-menu -->

--- a/templates/includes/menu.html
+++ b/templates/includes/menu.html
@@ -1,74 +1,74 @@
 <div id='page-wrapper' class='container'>
-  <div id='header' class='row-fluid'>
+<div id='header' class='row-fluid'>
     <a class="parent" href='http://eecs.oregonstate.edu'>School of Electrical Engineering and Computer Science</a>
     <h1><a href='/'>{{ SITENAME }}</a></h1>
-  </div>
+</div>
 
-  <!-- Read the Pelican page list and create menu structure -->
-  {% set pelpages = pages | menu_filter %}
+<!-- Read the Pelican page list and create menu structure -->
+{% set pelpages = (pages | menu_filter) + DIRECT_TEMPLATE_INFO %}
 
-  <ul id="mobile-menu" role="navigation">
+<ul id="mobile-menu" role="navigation">
     <li id="mobile-main-menu">
-      <ul class="menu">
-        <li class="first leaf"><a href="/" class="active">Home</a></li>
-        {% for page in pelpages %}
-        {% if page['children'] %}
-        <li class="expanded"><a href={{ page['link'] }}>{{ page['name'] }}</a>
-          <ul>
-            {% for child in page['children'] %}
-            <li class="leaf"><a href={{ child['link'] }}>{{ child['name'] }}</a></li>
-            {% endfor %}
-          </ul>
-        </li>
-        {% else %}
-        <li><a href={{ page['link'] }}>{{ page['name'] }}</a></li>
-        {% endif %}
-        {% endfor %}
-      </ul>
-    </li>
-    <li id="mobile-osu-top-hat">
-      <ul class="menu">
-        <li class="first leaf"><a href="http://calendar.oregonstate.edu">Calendar</a></li>
-        <li class="leaf"><a href="http://osulibrary.oregonstate.edu">Library</a></li>
-        <li class="leaf"><a href="http://oregonstate.edu/campusmap">Maps</a></li>
-        <li class="leaf"><a href="http://oregonstate.edu/main/online-services">Online Services</a></li>
-        <li class="last leaf"><a href="https://securelb.imodules.com/s/359/campaign/index.aspx?sid=359&amp;gid=34&amp;pgid=1982&amp;cid=3007" class="campaign">Make a Gift</a></li>
-      </ul>
-    </li>
-  </ul>
-  <!-- Main menu navbar -->
-  <div id='main-menu' role='navigation'>
-    <div class="region region-nav">
-      <div id="block-nice-menus-1" class="block block-nice-menus">
-        <div class="content">
-          <ul class="nice-menu nice-menu-down nice-menu-main-menu" id="nice-menu-1">
-            <li class="menu-217 menu-path-front first odd"><a href='/' class="active">Home</a></li>
+        <ul class="menu">
+            <li class="first leaf"><a href="/" class="active">Home</a></li>
             {% for page in pelpages %}
             {% if page['children'] %}
-            <li class="menuparent"><a href={{ page['link'] }}>{{ page['name'] }}</a>
-              <ul>
-                {% for child in page['children'] %}
-                {% if child['children'] %}
-                <li class="menuparent"><a href={{ child['link'] }}>{{ child['name'] }}</a>
-                  <ul>
-                    {% for grandchild in child['children'] %}
-                    <li><a href={{ grandchild['link'] }}>{{ grandchild['name'] }}</a></li>
+            <li class="expanded"><a href={{ page['link'] }}>{{ page['name'] }}</a>
+                <ul>
+                    {% for child in page['children'] %}
+                    <li class="leaf"><a href={{ child['link'] }}>{{ child['name'] }}</a></li>
                     {% endfor %}
-                  </ul>
-                </li>
-                {% else %}
-                <li><a href={{ child['link'] }}>{{ child['name'] }}</a></li>
-                {% endif %}
-                {% endfor %}
-              </ul>
+                </ul>
             </li>
             {% else %}
             <li><a href={{ page['link'] }}>{{ page['name'] }}</a></li>
             {% endif %}
             {% endfor %}
-          </ul>
+        </ul>
+    </li>
+    <li id="mobile-osu-top-hat">
+        <ul class="menu">
+            <li class="first leaf"><a href="http://calendar.oregonstate.edu">Calendar</a></li>
+            <li class="leaf"><a href="http://osulibrary.oregonstate.edu">Library</a></li>
+            <li class="leaf"><a href="http://oregonstate.edu/campusmap">Maps</a></li>
+            <li class="leaf"><a href="http://oregonstate.edu/main/online-services">Online Services</a></li>
+            <li class="last leaf"><a href="https://securelb.imodules.com/s/359/campaign/index.aspx?sid=359&amp;gid=34&amp;pgid=1982&amp;cid=3007" class="campaign">Make a Gift</a></li>
+        </ul>
+    </li>
+</ul>
+<!-- Main menu navbar -->
+<div id='main-menu' role='navigation'>
+    <div class="region region-nav">
+        <div id="block-nice-menus-1" class="block block-nice-menus">
+            <div class="content">
+                <ul class="nice-menu nice-menu-down nice-menu-main-menu" id="nice-menu-1">
+                    <li class="menu-217 menu-path-front first odd"><a href='/' class="active">Home</a></li>
+                    {% for page in pelpages %}
+                    {% if page['children'] %}
+                    <li class="menuparent"><a href={{ page['link'] }}>{{ page['name'] }}</a>
+                        <ul>
+                            {% for child in page['children'] %}
+                            {% if child['children'] %}
+                            <li class="menuparent"><a href={{ child['link'] }}>{{ child['name'] }}</a>
+                                <ul>
+                                    {% for grandchild in child['children'] %}
+                                    <li><a href={{ grandchild['link'] }}>{{ grandchild['name'] }}</a></li>
+                                    {% endfor %}
+                                </ul>
+                            </li>
+                            {% else %}
+                            <li><a href={{ child['link'] }}>{{ child['name'] }}</a></li>
+                            {% endif %}
+                            {% endfor %}
+                        </ul>
+                    </li>
+                    {% else %}
+                    <li><a href={{ page['link'] }}>{{ page['name'] }}</a></li>
+                    {% endif %}
+                    {% endfor %}
+                </ul>
+            </div>
         </div>
-      </div>
     </div>
-  </div>
+</div>
 <!-- /#main-menu -->


### PR DESCRIPTION
This uses Jinja2 templating and page metadata to generate a main menu. Exact metadata requirements are listed in this branch's README.

Remaining issues:
- Cannot include externally linked menu items
- Cannot include direct template pages (i.e. osuosl pelican blog page)

**work in progress**