### PR TITLE
Add standard and webkit gradient

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -109,7 +109,10 @@ div.content {
   font-size: 14px;
   line-height: 18px;
   padding: 20px 0 20px 20px;
+  background: #252525;
+  background: -webkit-linear-gradient(top, #39393a 0%, #252525 100%);
   background: -moz-linear-gradient(center top, #39393a 0%, #252525 100%) repeat scroll 0 0 transparent;
+  background: linear-gradient(to bottom,#39393a 0%,#252525 100%);
   min-height: 148px;
   border-top: 4px solid #dbd6d0; }
 

--- a/static/css/main.scss
+++ b/static/css/main.scss
@@ -111,7 +111,10 @@ div.content {
 	font-size: 14px;
 	line-height: 18px;
 	padding: 20px 0 20px 20px;
+	background: #252525;
+	background: -webkit-linear-gradient(top, #39393a 0%, #252525 100%);
 	background: -moz-linear-gradient(center top, #39393a 0%, #252525 100%) repeat scroll 0 0 transparent;
+	background: linear-gradient(to bottom,#39393a 0%,#252525 100%);
 	min-height: 148px;
 	border-top: 4px solid #dbd6d0;
 }


### PR DESCRIPTION
A fix for https://github.com/osuosl/dougfir-pelican-theme/issues/25

Add standard `linear-gradient` and `-webkit-linear-gradient`. I have added `background: #252525;` for browsers that don't support gradients.