### PR TITLE
Fix floating OSU tag

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -485,7 +485,6 @@ img {
   max-width: 100%;
   max-height: 470px;
   vertical-align: middle;
-  padding-top: 10px;
   padding-left: 10px;
   padding-right: 10px;
   padding-bottom: 10px; }


### PR DESCRIPTION
Fixes #31 

- [x] Makes the OSU logo stay where it belongs

Screenshot: 
![screenshot from 2016-07-29 14 45 25](https://cloud.githubusercontent.com/assets/1390653/17264339/2182af2e-559b-11e6-818e-87077591f02f.png)
