### PR TITLE
Fix sidebar logo.png href location

### DIFF
--- a/templates/includes/blog-sidebar.html
+++ b/templates/includes/blog-sidebar.html
@@ -2,7 +2,7 @@
     <div class="region region-sidebar-first">
         <div id="block-block-81" class="block block-block">
             <div class="content">
-                <p><a href="https://osuosl.org"><img src="{{ SITEURL }}/images/{{ SITELOGO }}" style="padding:-5px" /></a></p>
+                <p><a href="/"><img src="{{ SITEURL }}/images/{{ SITELOGO }}" style="padding:-5px" /></a></p>
             </div>
         </div>
         <div id="block-views-categories-block" class="block block-views">

--- a/templates/includes/footer.html
+++ b/templates/includes/footer.html
@@ -5,16 +5,16 @@
         <h3>Contact Info</h3>
         <div class="content">
           <p>
-            OSU Open Source Lab<br />
-            Kerr Admin B211<br />
+            Center for Applied Systems and Software<br />
+            209 &amp; 224 Milne Computer Center<br />
+            1800 SW Campus Way<br />
             Corvallis, OR 97331<br />
-            General Inquiries:<br /><span style="color: #C34500;"><a href="mailto:info@osuosl.org">info@osuosl.org</a></span><br />
-            Support for Project Infrastructure<br /><span style="color: #C34500;"><a href="mailto:support@osuosl.org">support@osuosl.org</a></span><br />
-            Questions about Donations:<br /><span style="color: #C34500;"><a href="mailto:donations@osuosl.org">donations@osuosl.org</a></span>
+            General Inquiries:<br /><span style="color: #C34500;"><a href="mailto:info@CASS.oregonstate.edu">info@CASS.oregonstate.edu</a></span><br />
+            Phone: 541-737-2060<br />
           </p>
         </div>
         <a href="http://oregonstate.edu/copyright">Copyright</a>
-        &copy;2015 Oregon State University<br />
+        &copy;2016 Oregon State University<br />
         <a href="http://oregonstate.edu/disclaimer">Disclaimer</a>
         </div
         <!-- Read the Pelican page list and create menu structure -->

--- a/templates/includes/footer.html
+++ b/templates/includes/footer.html
@@ -5,12 +5,13 @@
         <h3>Contact Info</h3>
         <div class="content">
           <p>
-            Center for Applied Systems and Software<br />
-            209 &amp; 224 Milne Computer Center<br />
-            1800 SW Campus Way<br />
-            Corvallis, OR 97331<br />
-            General Inquiries:<br /><span style="color: #C34500;"><a href="mailto:info@CASS.oregonstate.edu">info@CASS.oregonstate.edu</a></span><br />
-            Phone: 541-737-2060<br />
+            {{ SITENAME }}-- {{ NAME_ABBREV }}<br />
+            {{ ROOM }} {{ BUILDING }}<br />
+            {{ STREET_ADDRESS }}<br />
+            {% for e in EMAIL %}
+              <span style="color: #C34500;"><a href="mailto:{{ e }}">{{ e }}</a></span><br />
+            {% endfor %}
+            Phone: {{ PHONE_NUM }}
           </p>
         </div>
         <a href="http://oregonstate.edu/copyright">Copyright</a>

--- a/templates/includes/sidebar.html
+++ b/templates/includes/sidebar.html
@@ -2,7 +2,7 @@
     <div class="region region-sidebar-first">
         <div id="block-block-81" class="block block-block">
             <div class="content">
-                <p><a href="https://osuosl.org"><img src="{{ SITEURL }}/images/{{ SITELOGO }}" style="padding:-5px" /></a></p>
+                <p><a href="/"><img src="{{ SITEURL }}/images/{{ SITELOGO }}" style="padding:-5px" /></a></p>
             </div>
         </div>
         <div id="block-block-61" class="block block-block">


### PR DESCRIPTION
fixes issue [https://github.com/osu-cass/cass-pelican/issues/39](https://github.com/osu-cass/cass-pelican/issues/39)

- Before it was hardcoded to osuosl.org
- Changed to point towards home ` / `

## To test
```
make html
make devserver
```
click on logo in sidebar, should link to home

