### PR TITLE
Optionally disable sidebar

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -4568,5 +4568,16 @@ table {
     }
 }
 
+.nosidebar {
+    width: calc(100% - 20px) !important;
+}
+
+.nosidebar #content {
+    padding-right: 0 !important;
+}
+
+.nosidebar img {
+    padding-left: 0 !important;
+}
 
 /*# sourceMappingURL=main.css.map */

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,11 +10,17 @@
     <a href="#content" class="element-invisible element-focusable">Skip to main content</a>
 </div>
 <div class='row'>
-    <div class='row span9'>
-        {% block content %}
-        {% endblock content %}
-    </div>
-    {% include ('includes/blog-sidebar.html' if articles_page or article else 'includes/people-sidebar.html' if people else 'includes/sidebar.html') %}
+    {% if DISABLE_SIDEBAR %}
+        <div class='row span9 nosidebar'>
+            {% block content %}
+            {% endblock content %}
+        </div>
+    {% else %}
+        <div class='row span9'>
+            {{ self.content() }}
+        </div>
+        {% include ('includes/blog-sidebar.html' if articles_page or article else 'includes/people-sidebar.html' if people else 'includes/sidebar.html') %}
+    {% endif %}
 </div>
 </div>
     {% include 'includes/footer.html'%}


### PR DESCRIPTION
If `DISABLE_SIDEBAR` is set to `True` in the pelicanconf.py, the sidebar will be omitted.

To test:
1. Clone cass-pelican: `git clone https://github.com/osu-cass/cass-pelican`
2. Copy the contents of the theme to the newly created cass-pelican folder: `cp -r dougfir-pelican-theme cass-pelican`
3. `cd cass-pelican`
4. Install dependencies: `virtualenv venv` then `. venv/bin/activate` then `pip install -r requirements.txt`
5. Edit the `pelicanconf.py` and add `DISABLE_SIDEBAR = True`
6. Run `./develop_server.sh start`
7. Visit http://localhost:8000

With sidebar: 
![2016-08-04-111650_1920x1080_scrot](https://cloud.githubusercontent.com/assets/1390653/17413179/01579dd8-5a35-11e6-9371-684d76776434.png)

Without sidebar:
![2016-08-04-111614_1920x1080_scrot](https://cloud.githubusercontent.com/assets/1390653/17413185/0789d5ea-5a35-11e6-80bb-98d42dfe04b2.png)

Once this gets merged we can update the CASS site to remove the sidebar.