### PR TITLE
Fix ``All stories`` button

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -42,7 +42,7 @@
                         <span class='icon-chevron-left'>&#8250;</span>
                     </a>
                     <div class='more-link'>
-                        <a href='/news'>
+                        <a href={{ STORIES }}>
                             All stories
                         </a>
                     </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -42,7 +42,7 @@
                         <span class='icon-chevron-left'>&#8250;</span>
                     </a>
                     <div class='more-link'>
-                        <a href='/blog'>
+                        <a href='/news'>
                             All stories
                         </a>
                     </div>


### PR DESCRIPTION
Replaced the ``/blog`` link with a pelican variable.

While the OSL cycles through blog posts for its slide show, the CASS site cycles through news posts. The ``STORIES`` variable will allow the slide show source to be specified in pelicanconf.py.