### PR TITLE
Added Pelican Var + Question about the Homepage

### DIFF
--- a/templates/category.html
+++ b/templates/category.html
@@ -6,7 +6,7 @@
     <div id="block-system-main" class="block block-system">
 
       <div class="content">
-        <h1 class="title">{{ DEP_NAME }} Blog</h1>
+        <h1 class="title">{{ DEP_NAME }} {{NEWS_OR_BLOG }}</h1>
         {% for article in (articles_page.object_list if articles_page else articles) %}
         <h2 class='title page-title'><a href='/{{ article.url }}'>{{ article.title }}</a></h2>
         <div class="field field-name-field-subtitle field-type-text field-label-hidden">

--- a/templates/index.html
+++ b/templates/index.html
@@ -55,5 +55,26 @@
     </div>
 </div>
 
+{% if CASS_HOME_EXTRAS %}
+    <br>
+    <p>The Center for Applied Systems and Software (CASS) is a non-profit organization
+    that provides software development, testing and hosting solutions to clients
+    while giving students hands-on industry experience. Students are given the
+    opportunity and guidance to work with real-world clients and to see projects
+    from start to finish. CASS prides itself in offering quality services to
+    customers while providing a beneficial experience for our students.</p>
+    <p>CASS has three units, each with a specialized focus, that work closely together
+    to provide expanded services for clients and a more diverse experience for
+    students.</p>
+    
+    <ul class="simple">
+    <li><a class="reference external" href="cass.oregonstate.edu/units/osuosl/">Open Source Lab</a>: Open source hosting and software development</li>
+    <li><a class="reference external" href="cass.oregonstate.edu/units/software-dev-group/">Software Development Group</a>: Designs and develops applications for all major
+    platforms</li>
+    <li><a class="reference external" href="cass.oregonstate.edu/units/test-and-iot-lab/">Test and IoT Lab</a>: Hardware and software testing services and Internet of
+    Things (IoT) testing</li>
+    </ul>
+    <br>
+{% endif %}
 
 {% endblock %}


### PR DESCRIPTION
Currently, the homepage is set up so that it only displays *either* the slide show or ``home.rst``.

I've hard-coded some html into the dougfir theme as a temporary fix:
![more_content](https://cloud.githubusercontent.com/assets/6801364/17566719/6a110af6-5ef1-11e6-86eb-c935e122424d.png)

But my question is - Does anyone know of a way to include additional content on the homepage (beneath the slide show) without hard-coding it in?

Ideally, someone from CASS could just modify ``home.rst`` when they want to add content. Then, the html is generated by pelican and inserted beneath the slide show without them having to touch the dougfir theme.

@subnomo @Kennric @alxngyn @leian7 