### PR TITLE
Match EECS's header

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -59,6 +59,10 @@ a.parent, .parent, a.parent:hover {
   margin-top: 9px;
   display: inline-block; }
 
+a.parent:hover, a.parent:focus, a.parent:active {
+  color: #615042;
+}
+
 h2 {
   font-size: 22px;
   line-height: 32px; }
@@ -83,6 +87,7 @@ h4 {
 .region-sidebar-first > div, .region-sidebar-second > div {
   border-bottom: medium none !important; }
 
+/* site title */
 h1 a:hover, h1 a:active, h1 a:focus {
   color: #385e86; }
 
@@ -2625,8 +2630,8 @@ a:focus {
   outline: thin dotted #333;
   outline-offset: -2px; }
 
-a:hover, a:active {
-  outline: 0 none; }
+/* a:hover, a:active {
+  outline: 0 none; } */
 
 sub, sup {
   font-size: 75%;

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -50,6 +50,7 @@ h1 a {
 .parent + h1 {
   padding-top: 0; }
 
+/* 'College of Engineering' menu link */
 a.parent, .parent, a.parent:hover {
   color: #555;
   text-decoration: none;

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -44,15 +44,17 @@ h1 {
   padding: 1em 0 0; }
 
 h1 a {
+  color: #385e86;
   text-decoration: none; }
 
 .parent + h1 {
   padding-top: 0; }
 
-a.parent, .parent {
+a.parent, .parent, a.parent:hover {
+  color: #555;
   text-decoration: none;
   font-style: italic;
-  font-size: 18px;
+  font-size: 16px;
   margin-top: 9px;
   display: inline-block; }
 
@@ -80,8 +82,8 @@ h4 {
 .region-sidebar-first > div, .region-sidebar-second > div {
   border-bottom: medium none !important; }
 
-a:hover, a:active, a:focus {
-  color: #615042; }
+h1 a:hover, h1 a:active, h1 a:focus {
+  color: #385e86; }
 
 ul li {
   list-style-image: url(/theme/img/bullet.png);
@@ -2825,9 +2827,7 @@ a.text-success:hover, a.text-success:focus {
   color: #356635; }
 
 h1, h2, h3, h4, h5, h6 {
-  color: inherit;
-  font-family: inherit;
-  font-weight: bold;
+  font-weight: normal;
   line-height: 22px;
   margin: 11px 0;
   text-rendering: optimizelegibility; }
@@ -2837,7 +2837,7 @@ h1 small, h2 small, h3 small, h4 small, h5 small, h6 small {
   font-weight: normal;
   line-height: 1; }
 
-h1, h2, h3 {
+h2, h3 {
   line-height: 44px; }
 
 h5 {
@@ -4503,7 +4503,7 @@ table {
 }
 
 .title {
-  font-size: 1.5em;
+  font-size: 26px;
   color: #C34500;
 }
 

--- a/templates/includes/menu.html
+++ b/templates/includes/menu.html
@@ -1,6 +1,6 @@
 <div id='page-wrapper' class='container'>
 <div id='header' class='row-fluid'>
-    <a class="parent" href='http://eecs.oregonstate.edu'>School of Electrical Engineering and Computer Science</a>
+    <a class="parent" href='http://engineering.oregonstate.edu'>College of Engineering</a>
     <h1><a href='/'>{{ SITENAME }}</a></h1>
 </div>
 


### PR DESCRIPTION
Fixes #44 

### Changes in this PR
- [X] Changes site title font (Gudea --> EksjaExtremesRegular)
- [X] Changes site title color (orange --> blue)
- [X] Changes header's parent organization link ([EECS](eecs.oregonstate.edu) --> [COE](engineering.oregonstate.edu))
- [X] Changes spacing between site title and COE link (44px --> 22px)

### To test this PR:
1. ``cd cass-pelican/dougfir-pelican-theme`` or ``cd osuosl/dougfir-pelican-theme``
2. ``git checkout leian/match_COE`` (``git pull`` first if necessary)
3. ``cd ..``
4. ``make html``
5. ``make devserver``
6. Visit ``localhost:8000`` in your browser and click around. Each page should look something like this:
![match_coe](https://cloud.githubusercontent.com/assets/9158473/17599400/bcd7cbea-5fb3-11e6-9bec-c43db001eea5.png)

### Notes
When you squish the sides of the browser the site name wraps weirdly: 
![wrap](https://cloud.githubusercontent.com/assets/9158473/17599446/f1d0b6b8-5fb3-11e6-9c4f-32d4cab6d086.png)

This can be fixed in another PR unless someone has a quick fix?

@subnomo @Kennric @kelnera @athai @alxngyn 

