### PR TITLE
Other fixes to CASS homepage

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1422,6 +1422,8 @@ html.js .view-feature-story a.views-throbbing, html.js .view-feature-story span.
   box-shadow: 0 1px 2px #ccc;
   padding: 0 0.2em 0.2em 0;
   position: absolute;
+  top: 318px;
+  bottom: 24px;
   right: 25px;
   text-align: center;
   width: 75px;

--- a/templates/category.html
+++ b/templates/category.html
@@ -4,9 +4,13 @@
 <div id='content'>
   <div class="region region-content">
     <div id="block-system-main" class="block block-system">
-
       <div class="content">
+        {% if IS_CASS %}
         <h1 style='font-size:35px; padding-top:5px; color: #c34500'>{{ NAME_ABBREV }} {{NEWS_OR_BLOG }}</h1>
+        {% endif %}
+        {% if IS_OSL %}
+        <h1 class="title">{{ DEP_NAME }} {{NEWS_OR_BLOG }}</h1>
+        {% endif %}
         {% for article in (articles_page.object_list if articles_page else articles) %}
         <h2 class='title page-title'><a href='/{{ article.url }}'>{{ article.title }}</a></h2>
         <div class="field field-name-field-subtitle field-type-text field-label-hidden">

--- a/templates/category.html
+++ b/templates/category.html
@@ -6,10 +6,10 @@
     <div id="block-system-main" class="block block-system">
       <div class="content">
         {% if IS_CASS %}
-        <h1 style='font-size:35px; padding-top:5px; color: #c34500'>{{ NAME_ABBREV }} {{NEWS_OR_BLOG }}</h1>
+          <h1 style='font-size:35px; padding-top:5px; color: #c34500'>{{ NAME_ABBREV }} {{NEWS_OR_BLOG }}</h1>
         {% endif %}
         {% if IS_OSL %}
-        <h1 class="title">{{ DEP_NAME }} {{NEWS_OR_BLOG }}</h1>
+          <h1 class="title">{{ DEP_NAME }} {{NEWS_OR_BLOG }}</h1>
         {% endif %}
         {% for article in (articles_page.object_list if articles_page else articles) %}
         <h2 class='title page-title'><a href='/{{ article.url }}'>{{ article.title }}</a></h2>

--- a/templates/category.html
+++ b/templates/category.html
@@ -6,7 +6,7 @@
     <div id="block-system-main" class="block block-system">
 
       <div class="content">
-        <h1 class="title">{{ DEP_NAME }} {{NEWS_OR_BLOG }}</h1>
+        <h1 style='font-size:35px; padding-top:5px; color: #c34500'>{{ NAME_ABBREV }} {{NEWS_OR_BLOG }}</h1>
         {% for article in (articles_page.object_list if articles_page else articles) %}
         <h2 class='title page-title'><a href='/{{ article.url }}'>{{ article.title }}</a></h2>
         <div class="field field-name-field-subtitle field-type-text field-label-hidden">

--- a/templates/includes/blog-sidebar.html
+++ b/templates/includes/blog-sidebar.html
@@ -6,10 +6,22 @@
                     <p><a href="https://osuosl.org"><img src="{{ SITEURL }}/images/{{ SITELOGO }}" style="padding:-5px" /></a></p>
                 {% endif %}
                 {% if IS_CASS %}
-                    <div class="content">
-                        <h2 style="color: #c34500; font-size:25px; line-height:22px">Find Us Here</h2>
-                    </div>
-                    <p><a href="{{ SITELOG_URL }}"><img src="{{ SITEURL }}/images/{{ SITELOGO }}" style="padding:-5px" /></a></p>
+                    <p><img src="{{ SITEURL }}/images/{{ CASSLOGO }}" style="padding:-5px" /></p>
+                    <ul class='menu'>
+                        <p><a href="{{ SITELOG_URL }}"><img src="{{ SITEURL }}/images/{{ SITELOGO }}" style="padding:-5px" /></a></p>
+                        <p>
+                            {{ SITENAME }}<br />
+                            {{ BUILDING }}<br />
+                            {{ STREET_ADDRESS }}<br />
+                            {{ CITY_ZIP }}<br>
+    
+                            {% for e in EMAIL %}
+                                <a href="mailto:{{ e.address }}">{{ e.address }}</a><br>
+                            {% endfor %}
+                            Phone: {{ PHONE_NUM }}
+                        </p>
+                        <li class='leaf'><a href='{{ DONATE_LINK }}'><i class='fa fa-gift' aria-hidden='true'></i> Make a Gift</a></li>
+                    </ul>
                 {% endif %}
             </div>
         </div>

--- a/templates/includes/blog-sidebar.html
+++ b/templates/includes/blog-sidebar.html
@@ -2,7 +2,15 @@
     <div class="region region-sidebar-first">
         <div id="block-block-81" class="block block-block">
             <div class="content">
-                <p><a href="https://osuosl.org"><img src="{{ SITEURL }}/images/{{ SITELOGO }}" style="padding:-5px" /></a></p>
+                {% if IS_OSL %}
+                    <p><a href="https://osuosl.org"><img src="{{ SITEURL }}/images/{{ SITELOGO }}" style="padding:-5px" /></a></p>
+                {% endif %}
+                {% if IS_CASS %}
+                    <div class="content">
+                        <h2 style="color: #c34500; font-size:25px; line-height:22px">Find Us Here</h2>
+                    </div>
+                    <p><a href="{{ SITELOG_URL }}"><img src="{{ SITEURL }}/images/{{ SITELOGO }}" style="padding:-5px" /></a></p>
+                {% endif %}
             </div>
         </div>
         <div id="block-views-categories-block" class="block block-views">
@@ -13,6 +21,7 @@
                 <li class="views-row side-blog-list"><a href='/{{ article.url }}'>{{ article.title }}</a></li>
               {% endfor %}
             </ul>
+            {% if IS_OSL %}
             <ul class='menu'>
                 <li class='leaf'><a href="http://cass.oregonstate.edu" class="side-link">Center for Applied Systems and Software</a></li>
                 <li class='leaf'><a href="http://eecs.oregonstate.edu" class="side-link">Electrical Engineering and Computer Science</a></li>
@@ -34,6 +43,7 @@
         </div>
         <div>
           <h2><a href="http://lists.osuosl.org/mailman/listinfo/osl-newsletter">Newsletter Sign Up</a></h2>
+          {% endif %}
           <!-- <div class="content">
             <div class="view view-newletter-sign-up-form view-id-newletter_sign_up_form view-display-id-block view-dom-id-91a45f51554ee829dc6a37772f7a9f8d">
               <div class="view-content">

--- a/templates/includes/footer.html
+++ b/templates/includes/footer.html
@@ -2,16 +2,20 @@
   <div class='container'>
     <div class='row'>
       <div class='span2 contact'>
-        <h3>Contact Info</h3>
+        {% if IS_OSL %}
+          <h3>Contact Info</h3>
+        {% endif %}
         <div class="content">
           <p>
-            {{ SITENAME }}<br />
-            {{ ROOM }} {{ BUILDING }}<br />
-            {{ STREET_ADDRESS }}<br />
-            {% for e in EMAIL %}
-              <span style="color: #C34500;"><a href="mailto:{{ e.address }}">{{ e.address }}</a></span><br />
-            {% endfor %}
-            Phone: {{ PHONE_NUM }}
+            {% if IS_OSL %}
+              {{ SITENAME }}<br />
+              {{ ROOM }} {{ BUILDING }}<br />
+              {{ STREET_ADDRESS }}<br />
+              {% for e in EMAIL %}
+                <span style="color: #C34500;"><a href="mailto:{{ e.address }}">{{ e.address }}</a></span><br />
+              {% endfor %}
+              Phone: {{ PHONE_NUM }}
+            {% endif %}
           </p>
         </div>
         <a href="http://oregonstate.edu/copyright">Copyright</a>

--- a/templates/includes/sidebar.html
+++ b/templates/includes/sidebar.html
@@ -2,15 +2,14 @@
     <div class="region region-sidebar-first">
         <div id="block-block-81" class="block block-block">
             {% if IS_CASS %}
-            <div class="content">
-                <p><img src="{{ SITEURL }}/images/{{ CASSLOGO }}" style="padding:-5px" /></p>
-                <!-- <h2 style="color: #c34500; font-size:25px; line-height:22px">Find Us Here</h2> -->
-            </div>
+                <div class="content">
+                    <p><img src="{{ SITEURL }}/images/{{ CASSLOGO }}" style="padding:-5px" /></p>
+                </div>
             {% endif %}
             {% if IS_OSL%}
-            <div class="content">
-                <p><a href="{{ SITELOG_URL }}"><img src="{{ SITEURL }}/images/{{ SITELOGO }}" style="padding:-5px" /></a></p>
-            </div>
+                <div class="content">
+                    <p><a href="{{ SITELOG_URL }}"><img src="{{ SITEURL }}/images/{{ SITELOGO }}" style="padding:-5px" /></a></p>
+                </div>
             {% endif %}
         </div>
         {% if IS_CASS %}

--- a/templates/includes/sidebar.html
+++ b/templates/includes/sidebar.html
@@ -22,7 +22,12 @@
 		                    {{ SITENAME }}<br />
                         {{ BUILDING }}<br />
   	 	                  {{ STREET_ADDRESS }}<br />
-                        {{ CITY_ZIP }}	
+                        {{ CITY_ZIP }}<br>
+
+                        {% for e in EMAIL %}
+                            {{ e.address }}<br>
+                        {% endfor %}
+                        {{ PHONE_NUM }}
 		                </p>
                     <li class='leaf'><a href='{{ DONATE_LINK }}'><i class='fa fa-gift' aria-hidden='true'></i> Make a Gift</a></li>
                 </ul>

--- a/templates/includes/sidebar.html
+++ b/templates/includes/sidebar.html
@@ -25,9 +25,9 @@
                         {{ CITY_ZIP }}<br>
 
                         {% for e in EMAIL %}
-                            {{ e.address }}<br>
+                            <a href="mailto:{{ e.address }}">{{ e.address }}</a><br>
                         {% endfor %}
-                        {{ PHONE_NUM }}
+                        Phone: {{ PHONE_NUM }}
 		                </p>
                     <li class='leaf'><a href='{{ DONATE_LINK }}'><i class='fa fa-gift' aria-hidden='true'></i> Make a Gift</a></li>
                 </ul>

--- a/templates/includes/sidebar.html
+++ b/templates/includes/sidebar.html
@@ -3,23 +3,27 @@
         <div id="block-block-81" class="block block-block">
             {% if IS_CASS %}
             <div class="content">
-                <h2 style="color: #c34500; font-size:25px; line-height:22px">Find Us Here</h2>
+                <p><img src="{{ SITEURL }}/images/{{ CASSLOGO }}" style="padding:-5px" /></p>
+                <!-- <h2 style="color: #c34500; font-size:25px; line-height:22px">Find Us Here</h2> -->
             </div>
             {% endif %}
+            {% if IS_OSL%}
             <div class="content">
                 <p><a href="{{ SITELOG_URL }}"><img src="{{ SITEURL }}/images/{{ SITELOGO }}" style="padding:-5px" /></a></p>
             </div>
+            {% endif %}
         </div>
         {% if IS_CASS %}
         <div id="block-block-81" class="block block-block">
             <div class="content">
                 <ul class='menu'>
-                    <p>
+                    <p><a href="{{ SITELOG_URL }}"><img src="{{ SITEURL }}/images/{{ SITELOGO }}" style="padding:-5px" /></a></p>
+                    <li class='leaf'><br><p>
 		                    {{ SITENAME }}<br />
                         {{ BUILDING }}<br />
   	 	                  {{ STREET_ADDRESS }}<br />
                         {{ CITY_ZIP }}	
-		                </p>
+		                </p></li>
                     <li class='leaf'><a href='{{ DONATE_LINK }}'><i class='fa fa-gift' aria-hidden='true'></i> Make a Gift</a></li>
                 </ul>
             </div>

--- a/templates/includes/sidebar.html
+++ b/templates/includes/sidebar.html
@@ -18,12 +18,12 @@
             <div class="content">
                 <ul class='menu'>
                     <p><a href="{{ SITELOG_URL }}"><img src="{{ SITEURL }}/images/{{ SITELOGO }}" style="padding:-5px" /></a></p>
-                    <li class='leaf'><br><p>
+                    <p>
 		                    {{ SITENAME }}<br />
                         {{ BUILDING }}<br />
   	 	                  {{ STREET_ADDRESS }}<br />
                         {{ CITY_ZIP }}	
-		                </p></li>
+		                </p>
                     <li class='leaf'><a href='{{ DONATE_LINK }}'><i class='fa fa-gift' aria-hidden='true'></i> Make a Gift</a></li>
                 </ul>
             </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -41,7 +41,6 @@
                     <a id='next' class="side-controls next slick-next">
                         <span class='icon-chevron-left'>&#8250;</span>
                     </a>
-                    <br>
                     <div class='more-link'>
                         <a href={{ STORIES }}>
                             All stories
@@ -57,7 +56,8 @@
 </div>
 
 {% if CASS_HOME_EXTRAS %}
-    <br>
+    <!-- Temp soln: {include} functionality is an open PR on getpelican 
+                   Fixwhen it gets merged/Pelican 3.6.4 is released -->
     <p>The Center for Applied Systems and Software (CASS) is a non-profit organization
     that provides software development, testing and hosting solutions to clients
     while giving students hands-on industry experience. Students are given the

--- a/templates/index.html
+++ b/templates/index.html
@@ -69,10 +69,10 @@
     students.</p>
     
     <ul class="simple">
-    <li><a class="reference external" href="cass.oregonstate.edu/units/osuosl/">Open Source Lab</a>: Open source hosting and software development</li>
-    <li><a class="reference external" href="cass.oregonstate.edu/units/software-dev-group/">Software Development Group</a>: Designs and develops applications for all major
+    <li><a href="http://cass.oregonstate.edu/units/osuosl/">Open Source Lab</a>: Open source hosting and software development</li>
+    <li><a href="http://cass.oregonstate.edu/units/software-dev-group/">Software Development Group</a>: Designs and develops applications for all major
     platforms</li>
-    <li><a class="reference external" href="cass.oregonstate.edu/units/test-and-iot-lab/">Test and IoT Lab</a>: Hardware and software testing services and Internet of
+    <li><a href="http://cass.oregonstate.edu/units/test-and-iot-lab/">Test and IoT Lab</a>: Hardware and software testing services and Internet of
     Things (IoT) testing</li>
     </ul>
     <br>

--- a/templates/index.html
+++ b/templates/index.html
@@ -56,26 +56,8 @@
 </div>
 
 {% if CASS_HOME_EXTRAS %}
-    <!-- Temp soln: {include} functionality is an open PR on getpelican 
-                   Fixwhen it gets merged/Pelican 3.6.4 is released -->
-    <p>The Center for Applied Systems and Software (CASS) is a non-profit organization
-    that provides software development, testing and hosting solutions to clients
-    while giving students hands-on industry experience. Students are given the
-    opportunity and guidance to work with real-world clients and to see projects
-    from start to finish. CASS prides itself in offering quality services to
-    customers while providing a beneficial experience for our students.</p>
-    <p>CASS has three units, each with a specialized focus, that work closely together
-    to provide expanded services for clients and a more diverse experience for
-    students.</p>
-    
-    <ul class="simple">
-    <li><a href="http://cass.oregonstate.edu/units/osuosl/">Open Source Lab</a>: Open source hosting and software development</li>
-    <li><a href="http://cass.oregonstate.edu/units/software-dev-group/">Software Development Group</a>: Designs and develops applications for all major
-    platforms</li>
-    <li><a href="http://cass.oregonstate.edu/units/test-and-iot-lab/">Test and IoT Lab</a>: Hardware and software testing services and Internet of
-    Things (IoT) testing</li>
-    </ul>
-    <br>
+    {% set home_extras = pages[6] %}  <!-- Set to 6 to grab homepage extras --> 
+    {{ home_extras.content }}
 {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
Fixes https://github.com/osu-cass/cass-pelican/issues/73.

Currently the CASS homepage looks like this:
![sidebar_update2](https://cloud.githubusercontent.com/assets/6801364/17786530/1a951f72-653a-11e6-8d3a-acdf872a7f56.png)


## The following changes were also made:
* Update content in blog sidebar
* Add the 'Find us here' heading above the map (plus link fix)
* Increase font size of (blog) page heading
* Move heading up so that it aligns w/ sidebar
* Shortened "Center of Applied Systems and Software In The News" to "CASS In The News"

The news pages now looks like this:
![blog_sidebar](https://cloud.githubusercontent.com/assets/6801364/17786998/41a8317e-653c-11e6-8e63-61587e6937ca.png)


@Kennric @kelnera 