### PR TITLE
Featured Stories in Slideshow

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -9,7 +9,7 @@
         <div class="field field-name-field-subtitle field-type-text field-label-hidden">
           <div class="field-items">
             <div class="field-item even">
-              by {{ article.author }} on {{ article.date }}
+              by {{ article.author }} <!-- on {{ article.date }} -->
         </div></div></div>
         {% if article.img %}
         <div class="field field-name-field-featured-image field-type-image field-label-hidden">

--- a/templates/category.html
+++ b/templates/category.html
@@ -11,26 +11,28 @@
         {% if IS_OSL %}
           <h1 class="title">{{ DEP_NAME }} {{NEWS_OR_BLOG }}</h1>
         {% endif %}
+        <br>
         {% for article in (articles_page.object_list if articles_page else articles) %}
-        <h2 class='title page-title'><a href='/{{ article.url }}'>{{ article.title }}</a></h2>
-        <div class="field field-name-field-subtitle field-type-text field-label-hidden">
-          <div class="field-items">
-            <div class="field-item even">
-              by {{ article.author }} on {{ article.date }}
-        </div></div></div>
-        {% if article.img %}
-        <div class="field field-name-field-featured-image field-type-image field-label-hidden">
-          <div class="field-items">
-            <div class="field-item even">
-              <a href="/{{ article.url }}" class="active">
-                <img src="/images/{{ article.img }}" width="400" height="494" alt="" />
-              </a>
-            </div>
-          </div>
-        </div>
-        {% endif %}
-        {{ article.summary }}
-        <p><a href="/{{ article.url }}">Read more</a></p>
+            <h2><a href='/{{ article.url }}'>{{ article.title }}</a></h2>
+            <div class="field field-name-field-subtitle field-type-text field-label-hidden">
+              <div class="field-items">
+                <div class="field-item even">
+                  by {{ article.author }} <!-- on {{ article.date }} -->
+            </div></div></div>
+            <!-- Only display image if DISPLAY_IMAGE = True in pelicanconf -->
+            {% if article.img and DISPLAY_IMAGE %}
+                <div class="field field-name-field-featured-image field-type-image field-label-hidden">
+                  <div class="field-items">
+                    <div class="field-item even">
+                      <a href="/{{ article.url }}" class="active">
+                        <img src="/images/{{ article.img }}" width="400" height="494" alt="" />
+                      </a>
+                    </div>
+                  </div>
+                </div>
+            {% endif %}
+            {{ article.summary }}
+            <!-- <p><a href="/{{ article.url }}">Read more</a></p> -->
         {% endfor %}
 
         <ul class="pager">

--- a/templates/index.html
+++ b/templates/index.html
@@ -14,7 +14,7 @@
                 <div class="view view-feature-story view-id-feature_story view-display-id-block">
                     <div class='view-content front-page-story'>
                         {% for article in articles %}
-                            {% if article.category == FEATURED %}
+                            {% if article.tag == FEATURED %}
                                 <div class='fs-row'>
                                     <a href="{{ article.url }}">
                                         <img class='summary-image' alt="" src="{{ SITEURL }}/images/{{ article.img }} "></img>

--- a/templates/index.html
+++ b/templates/index.html
@@ -13,26 +13,27 @@
             <div class="content">
                 <div class="view view-feature-story view-id-feature_story view-display-id-block">
                     <div class='view-content front-page-story'>
-                        {% for article in articles[:5] %}
-                        <div class='fs-row'>
-                            <a href="{{ article.url }}">
-                                <img class='summary-image' alt="" src="{{ SITEURL }}/images/{{ article.img }} "></img>
-                            </a>
-                            <div class="views-field-field-caption">
-                                <h3 class="fs-title">
+                        {% for article in articles %}
+                            {% if article.category == FEATURED %}
+                                <div class='fs-row'>
                                     <a href="{{ article.url }}">
-                                        {{ article.title }}
+                                        <img class='summary-image' alt="" src="{{ SITEURL }}/images/{{ article.img }} "></img>
                                     </a>
-                                </h3>
-                                <p class="fs-caption">
-                                {% set summary = article.content | truncate(400) %}
-                                {% set summary = summary | close_html_tags %}
-                                {{ summary }}
-                                </p>
-                            </div>
-                        </div>
+                                    <div class="views-field-field-caption">
+                                        <h3 class="fs-title">
+                                            <a href="{{ article.url }}">
+                                                {{ article.title }}
+                                            </a>
+                                        </h3>
+                                        <p class="fs-caption">
+                                        {% set summary = article.content | truncate(400) %}
+                                        {% set summary = summary | close_html_tags %}
+                                        {{ summary }}
+                                        </p>
+                                    </div>
+                                </div>
+                            {% endif %}
                         {% endfor %}
-
                     </div>
 
                     <a id='prev' class="side-controls previous slick-prev">


### PR DESCRIPTION
Slide show fixes - should only display featured stories. Merge alongside https://github.com/osu-cass/cass-pelican/pull/88

**Note**: Article tags should be used in favor of category labels. Changing ``CATEGORY_SAVE_AS`` to be ``'news/{slug}/index.html`` makes it so that the full news page doesn't render.

@Kennric 