### PR TITLE
Minor fixes

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -235,7 +235,7 @@ input[type="image"] {
 
 caption, thead, tbody, tr, th, td {
   border-style: solid;
-  border-color: #e0e0e0;
+  border-color: transparent;
   border-width: 0; }
 
 caption {
@@ -250,10 +250,10 @@ tr, .ie7 td {
   border-bottom-width: 1px; }
 
 tr:nth-child(2n), tr.even {
-  background-color: #fff; }
+  background-color: transparent; }
 
 tr.odd, tr:nth-child(2n+1) {
-  background-color: #f5f2ed; }
+  background-color: transparent; }
 
 #sidebar-first tr.odd, #sidebar-first tr:nth-child(2n+1) {
   background-color: transparent; }

--- a/static/css/main.scss
+++ b/static/css/main.scss
@@ -238,7 +238,7 @@ input[type="image"] {
 }
 caption,thead,tbody,tr,th,td {
 	border-style: solid;
-	border-color: #e0e0e0;
+	border-color: transparent;
 	border-width: 0;
 }
 caption {
@@ -253,10 +253,10 @@ tr,.ie7 td {
 	border-bottom-width: 1px;
 }
 tr:nth-child(2n),tr.even {
-	background-color: #fff;
+	background-color: transparent;
 }
 tr.odd,tr:nth-child(2n+1) {
-	background-color: #f5f2ed;
+	background-color: transparent;
 }
 #sidebar-first tr.odd,#sidebar-first tr:nth-child(2n+1) {
 	background-color: transparent;


### PR DESCRIPTION
The table on the ``Partner With Us`` page now looks like this.
![cass_partners_table](https://cloud.githubusercontent.com/assets/6801364/18145680/18c8da48-6f81-11e6-82f1-890e1b2ac41e.png)

As for the slide show, it seems that removing it entirely (on mobile) may be the better option. The following are a list of issues a mobile slide show has:
* The caption function is broken - so article title and summary are not displayed
* Images are automatically resized and crops off the top
* A (large) gap is created between the bottom of the slide show and the home page description
* Next/Previous arrows need to be removed otherwise it breaks functionality for the non-mobile site
* The ``All Stories`` button floats awkwardly on the page

Alternatively, I think it'd be better to switch to a static image and default title once we hit a certain pixel width. Currently, the web page is set up to do exactly that, but since we haven't specified an image/title to use, it's defaulting to the most recent article and *its* image.

There are two options as to what we can use as the default mobile image.
1. The CASS staff image
2. A collage of images from the 5 featured articles

Option 1 is easiest since it probably won't need to be updated regularly.
Option 2 will take some work to maintain, but if we go with a collage, I can still make it link to ``News`` (like the ``All Stories`` button did). So even though the mobile site may be visually different from the regular website, it'll still be somewhat similar functionally.

What do you think?

@kelnera @Kennric 