### PR TITLE
Make title color configurable

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -58,6 +58,8 @@ a.parent, .parent, a.parent:hover {
 
 .title-blue {
   color: #385e86; }
+  .title-blue:hover, .title-blue:focus {
+    color: #385e86; }
   a.parent.title-blue, .parent.title-blue, a.parent:hover.title-blue {
     color: #555; }
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -42,22 +42,23 @@ h1 {
   font-size: 30px;
   margin: 0;
   padding: 1em 0 0; }
-
-h1 a {
-  color: #385e86;
-  text-decoration: none; }
+  h1 a {
+    text-decoration: none; }
+    h1 a.title-blue {
+      color: #385e86; }
 
 .parent + h1 {
   padding-top: 0; }
 
 /* 'College of Engineering' menu link */
 a.parent, .parent, a.parent:hover {
-  color: #555;
   text-decoration: none;
   font-style: italic;
   font-size: 16px;
   margin-top: 9px;
   display: inline-block; }
+  a.parent.title-blue, .parent.title-blue, a.parent:hover.title-blue {
+    color: #555; }
 
 a.parent:hover, a.parent:focus, a.parent:active {
   color: #615042; }
@@ -87,7 +88,7 @@ h4 {
   border-bottom: medium none !important; }
 
 /* site title */
-h1 a:hover, h1 a:active, h1 a:focus {
+h1 a:hover.title-blue, h1 a:active.title-blue, h1 a:focus.title-blue {
   color: #385e86; }
 
 ul li {
@@ -1391,7 +1392,8 @@ td.checkbox, th.checkbox {
   overflow: hidden;
   position: absolute;
   left: 0px;
-  top: 317px;  /* So the caption bar doesn't float */
+  top: 317px;
+  /* So the caption bar doesn't float */
   bottom: 10px;
   z-index: 100;
   width: 100%;
@@ -4487,7 +4489,8 @@ table {
 .summary-image {
   position: absolute;
   top: 30%;
-  transform: translate(0px, -30%); /* Change settings to align summ image */
+  transform: translate(0px, -30%);
+  /* Change settings to align summ image */
   width: 100%;
   height: auto; }
 
@@ -4575,5 +4578,3 @@ table {
 
 .m-icon-link i {
   display: inline !important; }
-
-/*# sourceMappingURL=main.css.map */

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -44,8 +44,6 @@ h1 {
   padding: 1em 0 0; }
   h1 a {
     text-decoration: none; }
-    h1 a.title-blue {
-      color: #385e86; }
 
 .parent + h1 {
   padding-top: 0; }
@@ -57,6 +55,9 @@ a.parent, .parent, a.parent:hover {
   font-size: 16px;
   margin-top: 9px;
   display: inline-block; }
+
+.title-blue {
+  color: #385e86; }
   a.parent.title-blue, .parent.title-blue, a.parent:hover.title-blue {
     color: #555; }
 
@@ -86,10 +87,6 @@ h4 {
 
 .region-sidebar-first > div, .region-sidebar-second > div {
   border-bottom: medium none !important; }
-
-/* site title */
-h1 a:hover.title-blue, h1 a:active.title-blue, h1 a:focus.title-blue {
-  color: #385e86; }
 
 ul li {
   list-style-image: url(/theme/img/bullet.png);

--- a/static/css/main.scss
+++ b/static/css/main.scss
@@ -44,22 +44,29 @@ h1 {
 	font-size: 30px;
 	margin: 0;
 	padding: 1em 0 0;
-}
-h1 a {
-    	color: #385e86;
-	text-decoration: none;
+
+	a {
+		text-decoration: none;
+
+		&.title-blue {
+			color: #385e86;
+		}
+	}
 }
 .parent + h1 {
 	padding-top: 0;
 }
 /* 'College of Engineering' menu link */
 a.parent, .parent, a.parent:hover {
-	color: #555;
 	text-decoration: none;
 	font-style: italic;
 	font-size: 16px;
 	margin-top: 9px;
 	display: inline-block;
+
+	&.title-blue {
+		color: #555;
+	}
 }
 a.parent:hover, a.parent:focus, a.parent:active {
 	color: #615042;
@@ -91,7 +98,9 @@ h4 {
 
 /* site title */
 h1 a:hover,h1 a:active,h1 a:focus {
-	color: #385e86;
+	&.title-blue {
+		color: #385e86;
+	}
 }
 ul li {
 	list-style-image: url(/theme/img/bullet.png);
@@ -4776,7 +4785,7 @@ table {
     #features {
         height: auto;
         min-height: 300px;
-    } 
+    }
 }
 
 .nosidebar {

--- a/static/css/main.scss
+++ b/static/css/main.scss
@@ -47,10 +47,6 @@ h1 {
 
 	a {
 		text-decoration: none;
-
-		&.title-blue {
-			color: #385e86;
-		}
 	}
 }
 .parent + h1 {
@@ -63,9 +59,15 @@ a.parent, .parent, a.parent:hover {
 	font-size: 16px;
 	margin-top: 9px;
 	display: inline-block;
+}
+.title-blue {
+	color: #385e86;
 
-	&.title-blue {
-		color: #555;
+	// Topmost title
+	@at-root {
+		a.parent#{&}, .parent#{&}, a.parent:hover#{&} {
+			color: #555;
+		}
 	}
 }
 a.parent:hover, a.parent:focus, a.parent:active {
@@ -94,13 +96,6 @@ h4 {
 }
 .region-sidebar-first > div,.region-sidebar-second > div {
 	border-bottom: medium none !important;
-}
-
-/* site title */
-h1 a:hover,h1 a:active,h1 a:focus {
-	&.title-blue {
-		color: #385e86;
-	}
 }
 ul li {
 	list-style-image: url(/theme/img/bullet.png);

--- a/static/css/main.scss
+++ b/static/css/main.scss
@@ -61,7 +61,12 @@ a.parent, .parent, a.parent:hover {
 	display: inline-block;
 }
 .title-blue {
-	color: #385e86;
+	$title-color: #385e86;
+	color: $title-color;
+
+	&:hover, &:focus {
+		color: $title-color;
+	}
 
 	// Topmost title
 	@at-root {

--- a/templates/includes/menu.html
+++ b/templates/includes/menu.html
@@ -1,7 +1,12 @@
 <div id='page-wrapper' class='container'>
 <div id='header' class='row-fluid'>
-    <a class="parent" href={{ PARENT_ORG_URL }}>{{ PARENT_ORG }}</a>
-    <h1><a href='/'>{{ SITENAME }}</a></h1>
+    {% if COLOR == 'blue' %}
+      <a class="parent title-blue" href={{ PARENT_ORG_URL }}>{{ PARENT_ORG }}</a>
+      <h1><a class="title-blue" href='/'>{{ SITENAME }}</a></h1>
+    {% else %}
+      <a class="parent" href={{ PARENT_ORG_URL }}>{{ PARENT_ORG }}</a>
+      <h1><a href='/'>{{ SITENAME }}</a></h1>
+    {% endif %}
 </div>
 
 <!-- Read the Pelican page list and create menu structure -->

--- a/templates/includes/menu.html
+++ b/templates/includes/menu.html
@@ -1,12 +1,7 @@
 <div id='page-wrapper' class='container'>
 <div id='header' class='row-fluid'>
-    {% if COLOR == 'blue' %}
-      <a class="parent title-blue" href={{ PARENT_ORG_URL }}>{{ PARENT_ORG }}</a>
-      <h1><a class="title-blue" href='/'>{{ SITENAME }}</a></h1>
-    {% else %}
-      <a class="parent" href={{ PARENT_ORG_URL }}>{{ PARENT_ORG }}</a>
-      <h1><a href='/'>{{ SITENAME }}</a></h1>
-    {% endif %}
+    <a class="parent title-{{COLOR}}" href={{ PARENT_ORG_URL }}>{{ PARENT_ORG }}</a>
+    <h1><a class="title-{{COLOR}}" href='/'>{{ SITENAME }}</a></h1>
 </div>
 
 <!-- Read the Pelican page list and create menu structure -->


### PR DESCRIPTION
In case we want a different colors for the title, it's now an option in the `pelicanconf.py`. The only color we have defined right now is blue, and it falls back to orange.

New colors can easily be added to the CSS by modifying this template:

```sass
.title-<color name here> {
    $title-color: <hex color here>;
    color: $title-color;

    &:hover, &:focus {
        color: $title-color;
    }

    // Topmost title
    @at-root {
        a.parent#{&}, .parent#{&}, a.parent:hover#{&} {
            color: <hex color here>;
        }
    }
}
```