### PR TITLE
Replace hardcoded parent organization info with pelican vars

### DIFF
--- a/templates/includes/menu.html
+++ b/templates/includes/menu.html
@@ -1,6 +1,6 @@
 <div id='page-wrapper' class='container'>
 <div id='header' class='row-fluid'>
-    <a class="parent" href='http://engineering.oregonstate.edu'>College of Engineering</a>
+    <a class="parent" href={{ PARENT_ORG_URL }}>{{ PARENT_ORG }}</a>
     <h1><a href='/'>{{ SITENAME }}</a></h1>
 </div>
 


### PR DESCRIPTION
Satisfies part of [this issue](https://github.com/osuosl/osuosl-pelican/issues/80).

Swaps out hardcoded COE information for information pulled from two pelican variables, PARENT_ORG_URL (parent organization website link) and PARENT_ORG (parent organization name). This way, CASS and COE can display different parent organization links on their respective homepages.

[Relevant CASS PR](https://github.com/osu-cass/cass-pelican/pull/91)
[Relevant OSL PR](https://github.com/osuosl/osuosl-pelican/pull/84)

## To test:
1. ``cd osuosl-pelican`` or ``cd cass-pelican``
2. ``git checkout leian/parent_org`` (git pull as necessary)
3. ``cd dougfir-pelican-theme``
4. ``git checkout leian/parent_org`` (git pull as necessary)
5. ``cd ../``
6. ``make devserver``
7. localhost:8000

@subnomo @athai @Kennric @alxngyn @kelnera 