### PR TITLE
add linked map stuff for footer if OSL

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -135,8 +135,7 @@ div.content {
 #footer h2, #footer h3 {
   color: #fff;
   font-size: 120%;
-  margin-top: 0;
-  line-height: auto; }
+  line-height: normal; }
 
 #footer a {
   color: #fff; }

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -146,6 +146,9 @@ div.content {
   text-decoration: none;
   border-radius: 3px; }
 
+#footer a img {
+  display: block; }
+
 #footer .block-menu {
   float: left; }
 
@@ -1391,7 +1394,8 @@ td.checkbox, th.checkbox {
   overflow: hidden;
   position: absolute;
   left: 0px;
-  top: 317px;  /* So the caption bar doesn't float */
+  top: 317px;
+  /* So the caption bar doesn't float */
   bottom: 10px;
   z-index: 100;
   width: 100%;
@@ -2830,7 +2834,6 @@ a.text-success:hover, a.text-success:focus {
   color: #356635; }
 
 h1, h2, h3, h4, h5, h6 {
-  font-weight: normal;
   line-height: 22px;
   margin: 11px 0;
   text-rendering: optimizelegibility; }
@@ -4487,7 +4490,8 @@ table {
 .summary-image {
   position: absolute;
   top: 30%;
-  transform: translate(0px, -30%); /* Change settings to align summ image */
+  transform: translate(0px, -30%);
+  /* Change settings to align summ image */
   width: 100%;
   height: auto; }
 

--- a/static/css/main.scss
+++ b/static/css/main.scss
@@ -138,8 +138,7 @@ div.content {
 #footer h2,#footer h3 {
 	color: #fff;
 	font-size: 120%;
-	margin-top: 0;
-	line-height: auto;
+	line-height: normal;
 }
 #footer a {
 	color: #fff;

--- a/static/css/main.scss
+++ b/static/css/main.scss
@@ -149,6 +149,9 @@ div.content {
 	text-decoration: none;
 	border-radius: 3px;
 }
+#footer a img {
+    display:block;
+}
 #footer .block-menu {
 	float: left;
 }
@@ -3021,7 +3024,6 @@ a.text-success:hover,a.text-success:focus {
 	color: #356635;
 }
 h1,h2,h3,h4,h5,h6 {
-	font-weight: normal;
 	line-height: 22px;
 	margin: 11px 0;
 	text-rendering: optimizelegibility;

--- a/templates/includes/blog-sidebar.html
+++ b/templates/includes/blog-sidebar.html
@@ -3,7 +3,7 @@
         <div id="block-block-81" class="block block-block">
             <div class="content">
                 {% if IS_OSL %}
-                    <p><a href="https://osuosl.org"><img src="{{ SITEURL }}/images/{{ SITELOGO }}" style="padding:-5px" /></a></p>
+                    <p><a href="https://osuosl.org"><img src="{{ SITEURL }}/images/{{ OSLLOGO }}" style="padding:-5px" /></a></p>
                 {% endif %}
                 {% if IS_CASS %}
                     <p><img src="{{ SITEURL }}/images/{{ CASSLOGO }}" style="padding:-5px" /></p>

--- a/templates/includes/footer.html
+++ b/templates/includes/footer.html
@@ -9,12 +9,13 @@
           <p>
             {% if IS_OSL %}
               {{ SITENAME }}<br />
-              {{ ROOM }} {{ BUILDING }}<br />
+              {{ BUILDING }}<br />
               {{ STREET_ADDRESS }}<br />
               {% for e in EMAIL %}
-                <span style="color: #C34500;"><a href="mailto:{{ e.address }}">{{ e.address }}</a></span><br />
+              <span style="color: #C34500;"><a href="mailto:{{ e.address }}">{{ e.address }}</a></span><br />
               {% endfor %}
               Phone: {{ PHONE_NUM }}
+              <p><a href="{{ SITELOG_URL }}"><img src="{{ SITEURL }}/images/{{ SITELOGO }}" /></a></p>
             {% endif %}
           </p>
         </div>

--- a/templates/includes/footer.html
+++ b/templates/includes/footer.html
@@ -11,6 +11,7 @@
               {{ SITENAME }}<br />
               {{ BUILDING }}<br />
               {{ STREET_ADDRESS }}<br />
+              {{ CITY_ZIP }}<br />
               {% for e in EMAIL %}
               <span style="color: #C34500;"><a href="mailto:{{ e.address }}">{{ e.address }}</a></span><br />
               {% endfor %}

--- a/templates/includes/sidebar.html
+++ b/templates/includes/sidebar.html
@@ -8,7 +8,7 @@
             {% endif %}
             {% if IS_OSL%}
                 <div class="content">
-                    <p><a href="{{ SITELOG_URL }}"><img src="{{ SITEURL }}/images/{{ SITELOGO }}" style="padding:-5px" /></a></p>
+                    <p><a href="{{ SITELOG_URL }}"><img src="{{ SITEURL }}/images/{{ OSLLOGO }}" style="padding:-5px" /></a></p>
                 </div>
             {% endif %}
         </div>


### PR DESCRIPTION
Satisfies part of this [osuosl-pelican issue](https://github.com/osuosl/osuosl-pelican/issues/80). 

If the given site is OSL's, then a linked Google map shows up in the footer. CASS's footer doesn't change. [Relevant osuosl-pelican PR](https://github.com/osuosl/osuosl-pelican/pull/78)

## To test:
1. ``cd osuosl-pelican`` or ``cd cass-pelican``
2. ``git checkout leian/osl_footer`` (git pull as necessary)
3. ``cd dougfir-pelican-theme``
4. ``git checkout leian/osl_footer`` (git pull as necessary)
5. ``cd ../``
6. ``make devserver``
7. localhost:8000

@subnomo @athai @Kennric @alxngyn @kelnera 