### PR TITLE
Match OSL header to CASS header

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -63,9 +63,6 @@ a.parent, .parent, a.parent:hover {
   a.parent.title-blue, .parent.title-blue, a.parent:hover.title-blue {
     color: #555; }
 
-a.parent:hover, a.parent:focus, a.parent:active {
-  color: #615042; }
-
 h2 {
   font-size: 22px;
   line-height: 32px; }
@@ -2729,6 +2726,9 @@ a:hover, a:focus {
   color: #762a00;
   text-decoration: underline; }
 
+h1 a:hover, h1 a:focus {
+  color: #c34500; }
+
 .row {
   margin-left: -20px; }
 
@@ -4578,3 +4578,5 @@ table {
 
 .m-icon-link i {
   display: inline !important; }
+
+/*# sourceMappingURL=main.css.map */

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -2727,8 +2727,7 @@ a {
   text-decoration: underline; }
 
 a:hover, a:focus {
-  color: #762a00;
-  /*	text-decoration: underline; */ }
+  color: #762a00; }
 
 h1 a:hover, h1 a:focus {
   color: #c34500;

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -2727,10 +2727,12 @@ a {
   text-decoration: underline; }
 
 a:hover, a:focus {
-  color: #762a00; }
+  color: #762a00;
+  /*	text-decoration: underline; */ }
 
 h1 a:hover, h1 a:focus {
-  color: #c34500; }
+  color: #c34500;
+  text-decoration: underline; }
 
 .row {
   margin-left: -20px; }

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -50,6 +50,7 @@ h1 {
 
 /* 'College of Engineering' menu link */
 a.parent, .parent, a.parent:hover {
+  color: #555;
   text-decoration: none;
   font-style: italic;
   font-size: 16px;
@@ -62,6 +63,9 @@ a.parent, .parent, a.parent:hover {
     color: #385e86; }
   a.parent.title-blue, .parent.title-blue, a.parent:hover.title-blue {
     color: #555; }
+
+a.parent:hover, a.parent:focus, a.parent:active {
+  color: #615042; }
 
 h2 {
   font-size: 22px;
@@ -2723,8 +2727,7 @@ a {
   text-decoration: underline; }
 
 a:hover, a:focus {
-  color: #762a00;
-  text-decoration: underline; }
+  color: #762a00; }
 
 h1 a:hover, h1 a:focus {
   color: #c34500; }

--- a/static/css/main.scss
+++ b/static/css/main.scss
@@ -2927,7 +2927,6 @@ a {
 }
 a:hover,a:focus {
 	color: #762a00;
-/*	text-decoration: underline; */
 }
 h1 a:hover, h1 a:focus {
     color: #c34500;

--- a/static/css/main.scss
+++ b/static/css/main.scss
@@ -75,9 +75,6 @@ a.parent, .parent, a.parent:hover {
 		}
 	}
 }
-a.parent:hover, a.parent:focus, a.parent:active {
-	color: #615042;
-}
 h2 {
 	font-size: 22px;
 	line-height: 32px;
@@ -2927,6 +2924,9 @@ a {
 a:hover,a:focus {
 	color: #762a00;
 	text-decoration: underline;
+}
+h1 a:hover, h1 a:focus {
+    color: #c34500;
 }
 .row {
 	margin-left: -20px;

--- a/static/css/main.scss
+++ b/static/css/main.scss
@@ -2927,9 +2927,11 @@ a {
 }
 a:hover,a:focus {
 	color: #762a00;
+/*	text-decoration: underline; */
 }
 h1 a:hover, h1 a:focus {
     color: #c34500;
+    text-decoration: underline;
 }
 .row {
 	margin-left: -20px;

--- a/static/css/main.scss
+++ b/static/css/main.scss
@@ -54,6 +54,7 @@ h1 {
 }
 /* 'College of Engineering' menu link */
 a.parent, .parent, a.parent:hover {
+    color: #555;
 	text-decoration: none;
 	font-style: italic;
 	font-size: 16px;
@@ -74,6 +75,9 @@ a.parent, .parent, a.parent:hover {
 			color: #555;
 		}
 	}
+}
+a.parent:hover, a.parent:focus, a.parent:active {
+    color: #615042;
 }
 h2 {
 	font-size: 22px;
@@ -2923,7 +2927,6 @@ a {
 }
 a:hover,a:focus {
 	color: #762a00;
-	text-decoration: underline;
 }
 h1 a:hover, h1 a:focus {
     color: #c34500;


### PR DESCRIPTION
Completes my portion of [this OSL issue](https://github.com/osuosl/osuosl-pelican/issues/80).
- [x] Fixes OSL header's CASS link colors
- [x] Fixes OSL header's title link hover color

Viewing:
![osl_header](https://cloud.githubusercontent.com/assets/9158473/18370193/26e6a4e2-75e0-11e6-8134-b10d13639f75.png)

Hovering:
![osl_header](https://cloud.githubusercontent.com/assets/9158473/18370406/9de98bbc-75e1-11e6-9c04-d3db3976ae86.png)

The CASS link should also change color slightly when you hover over it.

## To test:
1. From ``osuosl-pelican``, ``cd`` into the dougfir directory
2. Switch branches to ``leian/match_cass``
3. ``cd ..``
4. ``make devserver``
5. localhost:8000
6. Hover over the OSL header's CASS and title links
7. Do the same thing from ``cass-pelican`` and verify that the behavior is the same (excluding title link color)

@kelnera @Kennric @subnomo @athai @alxngyn 