### PR TITLE
Change variable name

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -58,7 +58,7 @@
 
 {% if CASS_HOME_EXTRAS %}
     {% for page in pages %} 
-        {% if page.tag == HOME_CONTENT %}
+        {% if page.tag == FRONTPAGE %}
             {{ page.content }}
         {% endif %}
     {% endfor %}
@@ -66,7 +66,7 @@
 
 {% if OSL_HOME_EXTRAS %}
     {% for page in pages %} 
-        {% if page.tag == HOME_CONTENT %}
+        {% if page.tag == FRONTPAGE %}
             {{ page.content }}
         {% endif %}
     {% endfor %}


### PR DESCRIPTION
The variable that determines the homepage content for the CASS pelican site differs from the one in the ``cass-pelican`` pelicanconf.py. Updated to match.