### PR TITLE
fix analytics fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ setup in the website themselves.
 
 ### Settings
 
-**GOOGLE_ANALTYICS**: Set to your tracking code to activate Google Analytics
+**GOOGLE_ANALYTICS**: Set to your tracking code to activate Google Analytics
 
 
 ### Menu

--- a/templates/includes/scripts.html
+++ b/templates/includes/scripts.html
@@ -1,4 +1,4 @@
-{% include 'analtyics.html' %}
+{% include 'includes/analytics.html' %}
 
 <script type="text/javascript" src="{{ SITEURL }}/theme/js/js-old/jquery-1.11.3.min.js"></script>
 <script type="text/javascript" src="{{ SITEURL }}/theme/js/slick/slick.min.js"></script>


### PR DESCRIPTION
Didn't catch this when @jldugger first opened #61, oops-- basically, this update changes ``{% include 'analtyics.html' %}`` to ``{% include 'includes/analytics.html' %}`` so that osuosl-pelican and cass-pelican don't break and produce ``TemplateNotFound`` errors when you try to do ``make html`` or ``make devserver``.

To verify this fix works:
1. ``cd`` into cass-pelican or osuosl-pelican and ``checkout`` to staging
2. ``cd`` into dougfir-pelican-theme and ``checkout`` to leian/analytics
3. ``make html`` and ``make devserver``; there should be no errors and the site should come up on localhost:8000

@osuosl/web-reviewers