### PR TITLE
Use FONT var in head.html

### DIFF
--- a/templates/includes/head.html
+++ b/templates/includes/head.html
@@ -9,4 +9,4 @@
 <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/js/slick/slick.css"/>
 <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
 <!-- Gudea Font -->
-<link href='http://fonts.googleapis.com/css?family=Gudea' rel='stylesheet' type='text/css'>
+<link href='{{ FONT }}' rel='stylesheet' type='text/css'>


### PR DESCRIPTION
Use FONT var as defined in pelicanconf.py rather than a hard-coded link.

TODO:
Update pelicanconf for CASS website