### PR TITLE
Kennric/fix announcement links

### DIFF
--- a/templates/includes/sidebar.html
+++ b/templates/includes/sidebar.html
@@ -37,7 +37,7 @@
                                 {% if article.img != '' %}
                                     <p><img src="{{ SITEURL }}/images/{{ article.img }}" style="padding:-5px"></img>
                                 {% endif %}
-                                <p><a href="{{ article.url }}" style="font-size:18px; text-decoration:none">{{ article.title }}</a></p>
+                                <p><a href="{{ SITEURL }}{{ article.url }}" style="font-size:18px; text-decoration:none">{{ article.title }}</a></p>
                                 <p>{{ article.summary }}</p><br>
                             {% endif %}
                         {% endfor %}


### PR DESCRIPTION
Without the SITEURL, the sidebar template generates a purely relative link to an announcement article, which works on the front page, but fails on sub pages.  

This fix makes the url absolute with the SITEURL.

NOTE: this fix will not work on a local build unless you set, -before building-, the PELICAN_SITE_URL environment variable to http://localhost:8000 (or whatever full URL points to your local build) 