### PR TITLE
odd even row coloring for powerdev

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -4583,4 +4583,12 @@ table {
 .m-icon-link i {
   display: inline !important; }
 
+table.powerdev-tbl tr:nth-child(even), tr.even {
+   background-color: #fff;
+ }
+
+table.powerdev-tbl tr:nth-child(odd), tr.odd {
+  background-color: #f5f2ed;
+  }
+
 /*# sourceMappingURL=main.css.map */


### PR DESCRIPTION
Odd-even row coloring for tables on POWERDev page
    
Nicked from the styling on old drupal page at http://d7.osuosl.org/services/powerdev
 
Browser support: http://caniuse.com/#search=nth

Part of https://github.com/osuosl/osuosl-pelican/pull/135