### PR TITLE
Table odd even row coloring globally

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -4583,4 +4583,16 @@ table {
 .m-icon-link i {
   display: inline !important; }
 
+table th {
+  text-align: left;
+}
+
+table tr:nth-child(even), tr.even {
+   background-color: #fff;
+}
+
+table tr:nth-child(odd), tr.odd {
+  background-color: #f5f2ed;
+}
+
 /*# sourceMappingURL=main.css.map */


### PR DESCRIPTION
This resolves #77 and supercedes it. In addition, this sets the table header to
be left aligned instead of center aligned.