### PR TITLE
Fix more mixed content warnings with fonts

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -4477,7 +4477,7 @@ a.label:hover, a.label:focus, a.badge:hover, a.badge:focus {
   font-family: "EksjaExtremesRegular";
   font-style: normal;
   font-weight: normal;
-  src: local(":"), url("http://oregonstate.edu/osuhomepage/css/fonts/Eksja/Eksja-regular-webfont.woff") format("woff"), url("http://oregonstate.edu/osuhomepage/css/fonts/Eksja/Eksja-regular-webfont.ttf") format("truetype"), url("http://oregonstate.edu/osuhomepage/css/fonts/Eksja/Eksja-regular-webfont.svg#webfont") format("svg"); }
+  src: local(":"), url("https://oregonstate.edu/osuhomepage/css/fonts/Eksja/Eksja-regular-webfont.woff") format("woff"), url("https://oregonstate.edu/osuhomepage/css/fonts/Eksja/Eksja-regular-webfont.ttf") format("truetype"), url("https://oregonstate.edu/osuhomepage/css/fonts/Eksja/Eksja-regular-webfont.svg#webfont") format("svg"); }
 #block-block-81 {
   margin-bottom: -10px;
   padding-bottom: 0em !important; }

--- a/static/css/main.scss
+++ b/static/css/main.scss
@@ -15,8 +15,8 @@
 }
 @font-face {
 	font-family: 'EksjaExtremesRegular';
-	src: url(http://oregonstate.edu/osuhomepage/css/fonts/Eksja/Eksja-regular-webfont.eot);
-	src: local(':'), url(http://oregonstate.edu/osuhomepage/css/fonts/Eksja/Eksja-regular-webfont.woff) format('woff'), url(http://oregonstate.edu/osuhomepage/css/fonts/Eksja/Eksja-regular-webfont.ttf) format('truetype'), url(http://oregonstate.edu/osuhomepage/css/fonts/Eksja/Eksja-regular-webfont.svg#webfont) format('svg');
+	src: url(https://oregonstate.edu/osuhomepage/css/fonts/Eksja/Eksja-regular-webfont.eot);
+	src: local(':'), url(https://oregonstate.edu/osuhomepage/css/fonts/Eksja/Eksja-regular-webfont.woff) format('woff'), url(https://oregonstate.edu/osuhomepage/css/fonts/Eksja/Eksja-regular-webfont.ttf) format('truetype'), url(https://oregonstate.edu/osuhomepage/css/fonts/Eksja/Eksja-regular-webfont.svg#webfont) format('svg');
 	font-weight: normal;
 	font-style: normal;
 }
@@ -4684,7 +4684,7 @@ a.label:hover,a.label:focus,a.badge:hover,a.badge:focus {
 	font-family: "EksjaExtremesRegular";
 	font-style: normal;
 	font-weight: normal;
-	src: local(":"), url("http://oregonstate.edu/osuhomepage/css/fonts/Eksja/Eksja-regular-webfont.woff") format("woff"), url("http://oregonstate.edu/osuhomepage/css/fonts/Eksja/Eksja-regular-webfont.ttf") format("truetype"), url("http://oregonstate.edu/osuhomepage/css/fonts/Eksja/Eksja-regular-webfont.svg#webfont") format("svg");
+	src: local(":"), url("https://oregonstate.edu/osuhomepage/css/fonts/Eksja/Eksja-regular-webfont.woff") format("woff"), url("https://oregonstate.edu/osuhomepage/css/fonts/Eksja/Eksja-regular-webfont.ttf") format("truetype"), url("https://oregonstate.edu/osuhomepage/css/fonts/Eksja/Eksja-regular-webfont.svg#webfont") format("svg");
 }
 #block-block-81 {
 	margin-bottom: -10px;


### PR DESCRIPTION
Turns out I missed some fonts, this should catch all of the mixed content warnings. For some reason they don't show up in the `devserver` website